### PR TITLE
feat: 팀 빌딩을 위한 알고리즘 구현

### DIFF
--- a/server/src/main/java/wap/web2/server/teambuild/Apply.java
+++ b/server/src/main/java/wap/web2/server/teambuild/Apply.java
@@ -1,0 +1,38 @@
+package wap.web2.server.teambuild;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Apply {
+    private String projectName;
+    private String position;
+    private Integer priority;
+
+    public Apply(String projectName, String position, Integer priority) {
+        this.projectName = projectName;
+        this.position = position;
+        this.priority = priority;
+    }
+
+    public static List<Apply> of(String position, List<String> names) {
+        List<Apply> applies = new ArrayList();
+
+        for(int i = 0; i < names.size(); ++i) {
+            applies.add(new Apply(names.get(i), position, i));
+        }
+
+        return applies;
+    }
+
+    public String getProjectName() {
+        return this.projectName;
+    }
+
+    public String getPosition() {
+        return this.position;
+    }
+
+    public Integer getPriority() {
+        return this.priority;
+    }
+}

--- a/server/src/main/java/wap/web2/server/teambuild/LeaderPriority.java
+++ b/server/src/main/java/wap/web2/server/teambuild/LeaderPriority.java
@@ -1,0 +1,24 @@
+package wap.web2.server.teambuild;
+
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Queue;
+
+public class LeaderPriority {
+    private int maxMemberNumber;
+    private Queue<String> memberNames;
+
+    public LeaderPriority(int maxMemberNumber, List<String> names) {
+        this.maxMemberNumber = maxMemberNumber;
+        this.memberNames = new ArrayDeque();
+        this.memberNames.addAll(names);
+    }
+
+    public Queue<String> getMemberNames() {
+        return this.memberNames;
+    }
+
+    public int getMaxMemberNumber() {
+        return this.maxMemberNumber;
+    }
+}

--- a/server/src/main/java/wap/web2/server/teambuild/TeamBuildApplication.java
+++ b/server/src/main/java/wap/web2/server/teambuild/TeamBuildApplication.java
@@ -1,0 +1,47 @@
+package wap.web2.server.teambuild;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TeamBuildApplication {
+    public static void main(String[] args) {
+
+        Map<String, List<Apply>> applyMap = new HashMap<>();
+        applyMap.put("김균호", Apply.of("backend", List.of("스타리스트", "딸깍", "커켓몬")));
+        applyMap.put("조강래", Apply.of("backend", List.of("커켓몬", "같이타요", "스타리스트")));
+        applyMap.put("고근호", Apply.of("backend", List.of("스타리스트", "딸깍", "같이타요")));
+        applyMap.put("박준용", Apply.of("backend", List.of("같이타요", "스타리스트", "커켓몬")));
+        applyMap.put("구교황", Apply.of("backend", List.of("스타리스트", "딸깍", "같이타요")));
+        applyMap.put("팔교황", Apply.of("backend", List.of("딸깍", "커켓몬", "스타리스트")));
+
+        Map<String, LeaderPriority> leaderPriorityMap = new HashMap<>();
+        leaderPriorityMap.put("스타리스트", new LeaderPriority(3, List.of("김균호", "조강래", "고근호", "박준용", "구교황", "팔교황")));
+        leaderPriorityMap.put("커켓몬", new LeaderPriority(3, List.of("박준용", "조강래", "김균호")));
+        leaderPriorityMap.put("같이타요", new LeaderPriority(2, List.of("조강래", "고근호", "구교황", "박준용")));
+        leaderPriorityMap.put("딸깍", new LeaderPriority(2, List.of("김균호", "팔교황", "고근호", "구교황")));
+
+        TeamBuilder teamBuilder = new TeamBuilder();
+        Map<String, List<String>> finalTeam = teamBuilder.allocate(applyMap, leaderPriorityMap);
+        System.out.println(finalTeam);
+        // result: {딸깍=[팔교황], 스타리스트=[김균호, 고근호, 구교황], 같이타요=[박준용], 커켓몬=[조강래]}
+
+        Map<String, List<Apply>> frontApplies = new HashMap<>();
+        frontApplies.put("김균호", Apply.of("frontend", List.of("스타리스트", "딸깍", "커켓몬")));
+        frontApplies.put("조강래", Apply.of("frontend", List.of("커켓몬", "같이타요", "스타리스트")));
+        frontApplies.put("고근호", Apply.of("frontend", List.of("스타리스트", "딸깍", "같이타요")));
+        frontApplies.put("박준용", Apply.of("frontend", List.of("같이타요", "스타리스트", "커켓몬")));
+        frontApplies.put("구교황", Apply.of("frontend", List.of("스타리스트", "딸깍", "같이타요")));
+        frontApplies.put("팔교황", Apply.of("frontend", List.of("딸깍", "커켓몬", "스타리스트")));
+
+        Map<String, LeaderPriority> frontPriorityMap = new HashMap<>();
+        frontPriorityMap.put("스타리스트", new LeaderPriority(1, List.of("김균호", "조강래", "고근호", "박준용", "구교황", "팔교황")));
+        frontPriorityMap.put("커켓몬", new LeaderPriority(2, List.of("박준용", "조강래", "김균호")));
+        frontPriorityMap.put("같이타요", new LeaderPriority(2, List.of("조강래", "고근호", "구교황", "박준용")));
+        frontPriorityMap.put("딸깍", new LeaderPriority(4, List.of("김균호", "팔교황", "고근호", "구교황")));
+
+        Map<String, List<String>> finalFrontTeam = teamBuilder.allocate(frontApplies, frontPriorityMap);
+        System.out.println(finalFrontTeam);
+        // result: {딸깍=[팔교황, 고근호, 구교황], 스타리스트=[김균호], 같이타요=[박준용], 커켓몬=[조강래]}
+    }
+}

--- a/server/src/main/java/wap/web2/server/teambuild/TeamBuilder.java
+++ b/server/src/main/java/wap/web2/server/teambuild/TeamBuilder.java
@@ -1,0 +1,87 @@
+package wap.web2.server.teambuild;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+public class TeamBuilder {
+
+    public Map<String, List<String>> allocate(Map<String, List<Apply>> applyMap,
+                                              Map<String, LeaderPriority> leaderPriorityMap) {
+        Map<String, List<String>> teams = new HashMap<>();
+
+        for (Map.Entry<String, LeaderPriority> entry : leaderPriorityMap.entrySet()) {
+            String teamName = entry.getKey();
+            teams.put(teamName, new LinkedList<>());
+            Integer num = entry.getValue().getMaxMemberNumber();
+            List<String> initialTeam = new LinkedList<>();
+
+            for (int i = 0; i < num; ++i) {
+                String first = entry.getValue().getMemberNames().poll();
+                initialTeam.add(first);
+            }
+
+            teams.get(teamName).addAll(initialTeam);
+        }
+
+        while (true) {
+            Set<String> names = this.getDuplicateMemberOf(teams);
+            if (names.isEmpty()) {
+                return teams;
+            }
+
+            for (String name : names) {
+                this.traceToMaxPriority(name, teams, applyMap, leaderPriorityMap);
+            }
+        }
+    }
+
+    private Set<String> getDuplicateMemberOf(Map<String, List<String>> team) {
+        int size = team.values().stream().mapToInt(List::size).sum();
+        Set<String> names = new HashSet<>(size); // resize 비용을 줄이기 위해
+        Set<String> duplicateNames = new HashSet<>(size / 3); // 중복은 잘 안일어날거 같아서 (지원자 수 / 3)으로 사이즈 제한
+
+        for (List<String> teamMembers : team.values()) {
+            for (String member : teamMembers) {
+                boolean isNew = names.add(member);
+                if (!isNew) {
+                    duplicateNames.add(member);
+                }
+            }
+        }
+
+        return duplicateNames;
+    }
+
+    private void traceToMaxPriority(String name, Map<String, List<String>> teams, Map<String, List<Apply>> applyMap,
+                                    Map<String, LeaderPriority> leaderPriorityMap) {
+        List<Apply> applies = applyMap.get(name);
+        boolean isJoin = false;
+
+        for (Apply apply : applies) {
+            String teamName = apply.getProjectName();
+            List<String> members = teams.get(teamName);
+            if (members.contains(name)) {
+                if (!isJoin) {
+                    isJoin = true;
+                } else {
+                    members.remove(name);
+                    this.addNewMember(teamName, members, leaderPriorityMap);
+                }
+            }
+        }
+
+    }
+
+    private void addNewMember(String teamName, List<String> members, Map<String, LeaderPriority> leaderPriorityMap) {
+        Queue<String> memberNames = leaderPriorityMap.get(teamName).getMemberNames();
+        if (!memberNames.isEmpty()) {
+            String newMember = memberNames.poll();
+            members.add(newMember);
+        }
+    }
+}

--- a/server/src/main/java/wap/web2/server/teambuild/TeamBuilder.java
+++ b/server/src/main/java/wap/web2/server/teambuild/TeamBuilder.java
@@ -14,6 +14,7 @@ public class TeamBuilder {
                                               Map<String, LeaderPriority> leaderPriorityMap) {
         Map<String, List<String>> teams = new HashMap<>();
 
+        // 팀장이 원하는대로 팀을 구성
         for (Map.Entry<String, LeaderPriority> entry : leaderPriorityMap.entrySet()) {
             String teamName = entry.getKey();
             teams.put(teamName, new LinkedList<>());
@@ -21,6 +22,7 @@ public class TeamBuilder {
             List<String> initialTeam = new LinkedList<>();
 
             for (int i = 0; i < num; ++i) {
+                // 지원자를 queue에서 제거해 임시 구성팀에게 할당한다.
                 String first = entry.getValue().getMemberNames().poll();
                 initialTeam.add(first);
             }
@@ -28,13 +30,18 @@ public class TeamBuilder {
             teams.get(teamName).addAll(initialTeam);
         }
 
+        // 일단 구성된 팀에서 중복된 인원을 제거하며 팀원을 할당합니다.
         while (true) {
+            // 먼저 여러 팀에 합류하고 있는 인원을 골라냅니다.
             Set<String> names = this.getDuplicateMemberOf(teams);
+
+            // 중복되는 인원이 없다면 모든 팀이 완성된 것입니다.
             if (names.isEmpty()) {
                 return teams;
             }
 
             for (String name : names) {
+                // 중복되는 인원은 자신이 가장 원하는 팀에 우선적으로 합류됩니다.
                 this.traceToMaxPriority(name, teams, applyMap, leaderPriorityMap);
             }
         }
@@ -57,19 +64,31 @@ public class TeamBuilder {
         return duplicateNames;
     }
 
+    /**
+     * 여러 팀에 합류해있는 사람은 우선순위가 가장 높은 팀으로 합류된다. 팀원을 잃은 팀은 새로운 멤버를 추가한다. 이 멤버는 leaderPriorityMap에 존재한다.
+     * @param name: 여러 팀에 합류해있는 사람
+     * @param teams: 현재까지 완성된 팀 명단
+     * @param applyMap: 모든 동아리원의 지원서를 담는 Map
+     * @param leaderPriorityMap: 팀장이 희망하는 팀원 명단
+     */
     private void traceToMaxPriority(String name, Map<String, List<String>> teams, Map<String, List<Apply>> applyMap,
                                     Map<String, LeaderPriority> leaderPriorityMap) {
-        List<Apply> applies = applyMap.get(name);
+        List<Apply> applies = applyMap.get(name); // 전달받은
         boolean isJoin = false;
 
         for (Apply apply : applies) {
             String teamName = apply.getProjectName();
             List<String> members = teams.get(teamName);
+
             if (members.contains(name)) {
+                // 가장 높은 우선순위를 가진 팀에게 할당
                 if (!isJoin) {
+                    // 할당 - (아무런 조치도 취하지 않음)
                     isJoin = true;
                 } else {
+                    // 지원자를 팀에서 빼야 함.
                     members.remove(name);
+                    // 새로운 지원자를 팀으로 합류시킴
                     this.addNewMember(teamName, members, leaderPriorityMap);
                 }
             }
@@ -77,9 +96,11 @@ public class TeamBuilder {
 
     }
 
+    // 현재 남아있는 팀원 명단 중 팀장이 가장 원하는 인원을 추가합니다.
     private void addNewMember(String teamName, List<String> members, Map<String, LeaderPriority> leaderPriorityMap) {
         Queue<String> memberNames = leaderPriorityMap.get(teamName).getMemberNames();
         if (!memberNames.isEmpty()) {
+            // 큐의 front에는 팀장이 가장 원하는 팀원이 있음
             String newMember = memberNames.poll();
             members.add(newMember);
         }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Web] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->

## ✨ PR 세부 내용
`TeamBuilder`의 allocate 메서드로 팀을 할당합니다. 포지션마다 팀원을 할당해야합니다.

`Apply`
- 원하는 팀에게 작성할 지원서를 담는 객체
- 프로젝트 이름과 우선순위, 포지션 등 지원에 필요한 최소한의 정보만 담았습니다. 엔티티로 추가해도 되고, dto로 전달받아도 괜찮을거 같습니다.

`LeaderPriority`
- 팀장이 원하는 팀원 리스트를 담은 객체
- Queue로 담고 있고, 최대 수용 가능 인원을 가짐
- 자신의 팀에게 지원한 지원자만 Queue에 들어가야 합니다. 다만 여기선 이 조건을 확인하지 않습니다. 테스트 시 입력에 주의해주세요.

`TeamBuilder`
- `allocate`: 인원별 지원서와 팀별 희망 팀원 리스트를 전달받아 각 팀에게 팀원을 적절히 할당합니다. 처음 for문을 순회하면서 임시 팀을 생성하고, 중복이 없을 때까지 팀원을 우선순위에 맞게 할당합니다.
- `traceToMaxPriority`: 팀원 할당에 핵심이 되는 로직으로 지원자가 원하는 팀에 합류할 수 있도록 합니다. `isJoin` 플래그로 가장 우선순위가 높은 팀에게 합류되고, 이미 join하였다면 나머지 팀들에게서 remove합니다.

``` 
# Test Case
김균호=[스타리스트, 딸각, 커켓몬]
조강래=[커켓몬, 같이타요, 스타리스트]
고근호=[스타리스트, 딸깍, 같이타요]
박준용=[같이타요, 스타리스트, 커켓몬]
구교황=[스타리스트, 딸깍, 같이타요]
팔교황=[딸깍, 커켓몬, 스타리스트]

스타리스트= 3명, [김균호, 조강래, 고근호, 박준용, 구교황, 팔교황]
커켓몬=    3명, [박준용, 조강래, 김균호]
같이타요=  2명, [조강래, 고근호, 구교황, 박준용]
딸깍=     2명, [김균호, 팔교황, 고근호, 구교황]

# result
{
    딸깍=[팔교황], 
    스타리스트=[김균호, 고근호, 구교황], 
    같이타요=[박준용], 
    커켓몬=[조강래]
}
```

## ⌛ 소요 시간