### PR TITLE
모집과 지원 페이지에 뒤로 가기 버튼을 추가

### DIFF
--- a/server/src/main/resources/templates/projects-application-for-leader.html
+++ b/server/src/main/resources/templates/projects-application-for-leader.html
@@ -312,9 +312,45 @@
                 justify-self: end;
             }
         }
+
+        /* Back button */
+        .topbar {
+            display: flex;
+            align-items: center;
+            margin-bottom: 12px;
+        }
+
+        .back-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            background: #ffffff;
+            color: var(--text);
+            border: 1px solid var(--border);
+            padding: 8px 12px;
+            border-radius: 10px;
+            font-weight: 700;
+            cursor: pointer;
+        }
+
+        .back-btn:hover {
+            filter: brightness(0.98);
+            border-color: #d4d7dd;
+        }
+
+        .back-btn .arrow {
+            font-size: 1rem;
+            line-height: 1;
+        }
     </style>
 </head>
 <body>
+
+<div class="topbar">
+    <button type="button" class="back-btn" onclick="goBack()">
+        <span class="arrow">←</span> 뒤로가기
+    </button>
+</div>
 
 <h2>모집하기 페이지</h2>
 
@@ -746,6 +782,11 @@
                 `<span class="err">[실패] ${err?.message || err}</span>`;
         }
     });
+
+    // 돌아가기 기능
+    function goBack() {
+        window.history.go(-2);
+    }
 </script>
 </body>
 </html>

--- a/server/src/main/resources/templates/projects-application.html
+++ b/server/src/main/resources/templates/projects-application.html
@@ -588,6 +588,36 @@
                 font-size: .95rem;
             }
         }
+
+        /* Back button */
+        .topbar {
+            display: flex;
+            align-items: center;
+            margin-bottom: 12px;
+        }
+
+        .back-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            background: #ffffff;
+            color: var(--text);
+            border: 1px solid var(--border);
+            padding: 8px 12px;
+            border-radius: 10px;
+            font-weight: 700;
+            cursor: pointer;
+        }
+
+        .back-btn:hover {
+            filter: brightness(0.98);
+            border-color: #d4d7dd;
+        }
+
+        .back-btn .arrow {
+            font-size: 1rem;
+            line-height: 1;
+        }
     </style>
 </head>
 <body>
@@ -595,6 +625,12 @@
     <div class="header">
         <h1>WAP 팀빌딩</h1>
         <p>지원서를 작성하고 원하는 프로젝트들에 한 번에 지원하세요!</p>
+    </div>
+    <!-- 뒤로 가기 버튼 -->
+    <div class="topbar">
+        <button type="button" class="back-btn" onclick="goBack()">
+            <span class="arrow">←</span> 뒤로가기
+        </button>
     </div>
 
     <!-- 공통 지원서 작성 섹션 -->
@@ -749,6 +785,11 @@
     let commonApplication = null;
     // 선택된 프로젝트 목록
     let selectedProjects = new Set();
+
+    // 돌아가기 기능
+    function goBack() {
+        window.history.go(-2);
+    }
 
     // 공통 지원서 작성 모달 열기
     function openApplicationModal() {


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Web] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->

## ✨ PR 세부 내용
모집과 지원 페이지에서 뒤로 가기 버튼을 추가하였습니다.

최종 결과 페이지에서 사용하던 뒤로가기 기능을 참고하여 만들었습니다. 

<img width="700" height="279" alt="image" src="https://github.com/user-attachments/assets/e601b453-c230-4442-bc37-66c7252186bc" />

<img width="700" height="517" alt="image" src="https://github.com/user-attachments/assets/5c6e4988-e231-46d1-8288-ae8930508da1" />



## ⌛ 소요 시간