### PR TITLE
entry 메서드에서 생성한 token을 사용하도록 수정

### DIFF
--- a/server/src/main/java/wap/web2/server/teambuild/controller/TeamBuildControllerV1.java
+++ b/server/src/main/java/wap/web2/server/teambuild/controller/TeamBuildControllerV1.java
@@ -35,7 +35,8 @@ public class TeamBuildControllerV1 {
                         @CookieValue(name = "authToken", required = false) String cookieToken,
                         @RequestHeader(value = "Authorization", required = false) String authHeader,
                         HttpServletResponse response) throws Exception {
-
+        log.info("[/team-build] entry parameter is null: userPrincipal={}, cookieToken={}, authHeader{}",
+                userPrincipal == null, cookieToken == null, authHeader == null);
         // 1) 쿠키에 토큰이 이미 있으면 그걸 사용
         String token = (cookieToken != null && !cookieToken.isBlank()) ? cookieToken : null;
 
@@ -46,7 +47,7 @@ public class TeamBuildControllerV1 {
             ResponseCookie set = ResponseCookie.from("authToken", token)
                     .httpOnly(false)          // 타임리프 JS에서 읽어야 하면 false (가능하면 다른 안전한 주입 방식 권장)
                     .secure(true)             // https 환경에서만
-                    .sameSite("None")         // 프론트/백 분리(크로스 도메인)면 None
+                    .sameSite("Lax")         // 프론트/백 분리(크로스 도메인)면 None
                     .path("/")
                     .maxAge(java.time.Duration.ofDays(7))
                     .build();
@@ -58,8 +59,8 @@ public class TeamBuildControllerV1 {
         boolean isLeader = projectService.isLeader(userId);
 
         return isLeader
-                ? recruitPage(model, cookieToken, userPrincipal)
-                : projects(model, cookieToken);
+                ? recruitPage(model, token, userPrincipal)
+                : projects(model, token);
     }
 
     @GetMapping("/projects")


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Web] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->

##  📌 관련 이슈

- #309

## ✨ PR 세부 내용
사파리나 모바일 환경에서 쿠키가 정상적으로 생성되지 못하는 오류를 수정하였습니다. 

우선 쿠키가 생성될 수 있도록 SameSite를 Lax로 변경하고, 팀 리더인지 판별 후 페이지를 옮기는 과정에서 cookieToken이 아니라 token을 사용하기로 했습니다.

token은 entry 메서드 내에서 쿠키 내의 authToken 값이나 Authorization 값을 가지게 됩니다. 이를 활용하면 문제 없이 작동할 것이라 판단됩니다.!

<!-- 수정/추가한 내용을 적어주세요. -->

## ⌛ 소요 시간