### PR TITLE
fix: 프로젝트 상세글 작성가 아님에도 수정/삭제가 보이는 버그 수정(#339)

### DIFF
--- a/client/src/components/ProjectDetail/ProjectDetailForm.js
+++ b/client/src/components/ProjectDetail/ProjectDetailForm.js
@@ -32,16 +32,11 @@ const ProjectDetailForm = () => {
         setProjectData(data); // 프로젝트 데이터 설정
         console.log("API 응답 데이터:", data);
 
-        if (token) {
-          const decodedToken = jwtDecode(token); // JWT 디코딩
-          // console.log("디코딩된 토큰:", decodedToken);
-
-          // 토큰에서 추출한 ID와 프로젝트 작성자 ID 비교
-          if (decodedToken.userId === data.ownerId) {
-            setIsOwner(true);
-          } else {
-            setIsOwner(false);
-          }
+        // 작성자인지 여부 확인
+        if (data.isOwner === true) {
+          setIsOwner(true);
+        } else {
+          setIsOwner(false);
         }
 
         // 일정 시간 후 데이터 렌더링을 완료하도록 설정


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Web] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #339 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
1. 기존 프론트 코드에서도 사용자가 작성자가 맞는 검증하는 로직은 존재했으나, dto에서 존재하지 않는 필드의 값을 꺼내와서 비교하고 있었음.
2. 백엔드에서 프로젝트 상세 정보 GET 요청에 `isOwner` 필드를 추가해서  사용자가 작성자인지 여부를 프론트로 직접 보내주기로 함.
3. 프론트에서는 단순하게 `isOwner`의 값에 따라 버튼을 보여줄지 여부를 정함
## ⌛ 소요 시간