### PR TITLE
feat : 2차 팀빌딩 페이지 추가

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -13,6 +13,7 @@ import VoteResultPage from "./pages/VoteResultPage";
 import RoleSelectPage from "./pages/RoleSelectPage";
 import TeamBuildPage from "./pages/TeamBuildPage";
 import TeamBuildApplyPage from "./pages/TeamBuildApplyPage";
+import TeamBuildApplyPage2nd from "./pages/TeamBuildApplyPage2nd";
 import TeamBuildEntryPage from "./pages/TeamBuildEntryPage";
 import TeamBuildResultPage from "./pages/TeamBuildResultPage";
 import CalendarPage from "./pages/CalendarPage";
@@ -65,6 +66,7 @@ function App() {
           <Route path="/select/role" element={<RoleSelectPage />} />
           <Route path="/team-build" element={<TeamBuildEntryPage />} />
           <Route path="/team-build/projects" element={<TeamBuildApplyPage />} />
+          <Route path="/team-build/projects/2nd" element={<TeamBuildApplyPage2nd />} />
           <Route path="/team-build/recruit" element={<TeamBuildPage />} />
           <Route path="/team-build/result" element={<TeamBuildResultPage />} />
           <Route path="/calendar" element={<CalendarPage />} />

--- a/client/src/assets/TeamBuildApply.module.css
+++ b/client/src/assets/TeamBuildApply.module.css
@@ -161,10 +161,6 @@
   line-height: 1.4;
 }
 
-.notice {
-  flex-direction: column;
-}
-
 .myApply {
   width: 100%;
   box-sizing: border-box;

--- a/client/src/assets/TeamBuildApply2nd.module.css
+++ b/client/src/assets/TeamBuildApply2nd.module.css
@@ -1,0 +1,1900 @@
+.page {
+  position: relative;
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+  min-height: 100vh;
+  color: #f7f7f7;
+  background:
+    radial-gradient(900px 480px at 15% 0%, rgba(150, 170, 210, 0.65), transparent 60%),
+    radial-gradient(720px 520px at 100% 10%, rgba(120, 190, 210, 0.45), transparent 55%),
+    linear-gradient(180deg, #8ea1bf 0%, #5c6d84 28%, #2b333b 58%, #0b0b0d 100%);
+  overflow-x: hidden;
+}
+
+.page::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(460px 240px at 12% 30%, rgba(255, 255, 255, 0.08), transparent 60%),
+    radial-gradient(520px 320px at 85% 40%, rgba(255, 255, 255, 0.06), transparent 60%);
+  pointer-events: none;
+}
+
+.shell {
+  position: relative;
+  z-index: 1;
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 20px 18px 80px;
+}
+
+.topBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 30px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.brandLogo {
+  height: 18px;
+  opacity: 0.9;
+}
+
+.brandText {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.closeButton {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(0, 0, 0, 0.3);
+  color: #fff;
+  font-size: 22px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: 0.2s ease;
+}
+
+.closeButton:hover {
+  border-color: rgba(255, 255, 255, 0.5);
+  transform: scale(1.03);
+}
+
+.hero {
+  text-align: center;
+  margin-bottom: 42px;
+}
+
+.heroTitle {
+  font-size: 34px;
+  font-weight: 800;
+  letter-spacing: -1px;
+}
+
+.heroSubtitle {
+  margin-top: 8px;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.notice {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.185);
+  border-radius: 26px;
+  margin: 24px 0 10px;
+}
+
+.noticeButton {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 20px;
+  box-sizing: border-box;
+  border: none;
+  background: transparent;
+  color : #f7f7f7;
+  cursor: pointer;
+}
+
+.noticeIcon{
+  display: block;
+  width: 20px;
+  height: 20px;
+}
+
+.noticeTitle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  
+}
+
+.noticeArrow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: auto;
+  flex-shrink: 0;
+  transition: transform 0.2s ease;
+}
+
+.noticeArrow img {
+  display: block;
+  width: 15px;
+  height: 15px;
+}
+
+.noticeArrowOpen {
+  transform: rotate(90deg);
+}
+
+.noticeContent {
+  width: 100%;
+  padding: 0 20px 20px;
+  box-sizing: border-box;
+}
+
+.noticeContent p {
+  margin: 4px 0;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.notice {
+  flex-direction: column;
+}
+
+.myApply {
+  width: 100%;
+  box-sizing: border-box;
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 26px;
+  padding: 22px 20px;
+  margin-bottom: 10px;
+  box-shadow: 0 22px 50px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(8px);
+}
+
+.completedApply {
+  margin-top: 120px;
+}
+
+.myApplyHeader {
+  display: block;
+}
+
+.myApplyTitle {
+  display: block;
+}
+
+.myApplyTitleRow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.myApplyHeader h2 {
+  margin: 2px 0 2px 13px;
+  font-size: 18px;
+  font-weight: 600;
+  color: #f7f7f7;
+}
+
+.myApplyTitle p {
+  margin: 9px 0 0 13px;
+  color: rgba(255, 255, 255, 0.379);
+  font-size: 13px;
+  line-height: 1.45;
+  text-align: left;
+}
+
+.myApplyTitle p + p {
+  margin-top: 3px;
+}
+
+.myApplyCount {
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 12px;
+  font-weight: 800;
+  margin-top: 0;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.myApplyCountActive {
+  background: #9ed0ff;
+  color: #000000;
+}
+
+.primaryPositionCard {
+  width: 100%;
+  box-sizing: border-box;
+  margin-bottom: 10px;
+  margin-top: 20px;
+  padding: 18px 16px;
+  border-radius: 26px;
+  background: rgba(255, 255, 255, 0.059);
+  backdrop-filter: blur(8px);
+}
+
+.primaryPositionHeader h2 {
+  margin: 0 0 0 8px;
+  color: #f7f7f7ac;
+  font-size: 17px;
+  font-weight: 600;
+}
+
+.primaryPositionHeader p {
+  margin: 4px 0 0 8px;
+  color: rgba(255, 255, 255, 0.205);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.formGroup.primaryPositionSelect {
+  position: relative;
+  margin: 10px 8px 0;
+}
+
+.formGroup.primaryPositionSelect::after {
+  content: "";
+  position: absolute;
+  top: 13px;
+  right: 16px;
+  width: 8px;
+  height: 8px;
+  border-right: 1.5px solid #d9e2f1;
+  border-bottom: 1.5px solid #d9e2f1;
+  pointer-events: none;
+  transform: rotate(45deg);
+}
+
+.formGroup.primaryPositionSelect select {
+  appearance: none !important;
+  -webkit-appearance: none !important;
+  -moz-appearance: none !important;
+  padding-top: 9px;
+  padding-bottom: 9px;
+  border-color: rgba(255, 255, 255, 0.22);
+  background-color: rgba(255, 255, 255, 0.14);
+  background-image: none !important;
+  color-scheme: dark;
+}
+
+.formGroup.primaryPositionSelect select::-ms-expand {
+  display: none;
+}
+
+.formGroup.primaryPositionSelect select:focus,
+.formGroup.primaryPositionSelect select:focus-visible {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.22);
+  box-shadow: none;
+}
+
+.formGroup.primaryPositionSelect option {
+  background-color: #292a2e;
+  color: #f8f8f8;
+}
+
+.emptyApply {
+  min-height: 240px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.emptyFolder {
+  width: 120px;
+  height: auto;
+  object-fit: contain;
+  opacity: 0.3;
+  margin-top: 20px;
+}
+
+.emptyApply p {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.45;
+  color: rgba(255, 255, 255, 0.65);
+  margin-bottom: 30px;
+}
+
+.stepGuide {
+  margin-bottom: 18px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: stretch;
+  gap: 10px;
+}
+
+.stepCard {
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(6, 9, 13, 0.5);
+  padding: 12px 14px;
+}
+
+.stepCardDone {
+  border-color: rgba(143, 212, 122, 0.5);
+  background: rgba(82, 120, 78, 0.2);
+}
+
+.stepCardCurrent {
+  border-color: rgba(169, 205, 246, 0.7);
+  box-shadow: 0 0 0 1px rgba(169, 205, 246, 0.25) inset;
+}
+
+.stepCardLocked {
+  opacity: 0.7;
+}
+
+.stepMeta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.stepNumber {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.stepStatus {
+  font-size: 11px;
+  font-weight: 700;
+  color: #a9cdf6;
+}
+
+.stepLabel {
+  font-size: 14px;
+  font-weight: 700;
+  margin-bottom: 3px;
+}
+
+.stepHint {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.stepDivider {
+  width: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.stepDivider::before {
+  content: "→";
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 14px;
+}
+
+.panel {
+  background: rgba(14, 14, 14, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 26px;
+  padding: 22px 20px;
+  box-shadow: 0 22px 50px rgba(0, 0, 0, 0.45);
+  margin-bottom: 20px;
+  backdrop-filter: blur(8px);
+}
+
+.stepStack {
+  display: grid;
+  gap: 16px;
+}
+
+.editablePanel {
+  margin-bottom: 0;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.editablePanelActive {
+  border-color: rgba(159, 199, 242, 0.48);
+  box-shadow: 0 22px 50px rgba(0, 0, 0, 0.45), 0 0 0 1px rgba(159, 199, 242, 0.2) inset;
+}
+
+.editableHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.editableTitleWrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.stepChip {
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.stepChipCurrent {
+  border-color: rgba(169, 205, 246, 0.58);
+  background: rgba(169, 205, 246, 0.2);
+  color: #deecff;
+}
+
+.stepChipDone {
+  border-color: rgba(142, 215, 130, 0.5);
+  background: rgba(142, 215, 130, 0.2);
+  color: #e4ffe0;
+}
+
+.stepChipLocked {
+  border-color: rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.62);
+}
+
+.editButton {
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.92);
+  border-radius: 999px;
+  padding: 7px 12px;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: 0.2s ease;
+}
+
+.editButton:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.sectionSummary {
+  margin-top: 12px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 14px;
+  padding: 12px;
+}
+
+.summaryRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.summaryRow strong {
+  color: #f6f6f6;
+  font-size: 13px;
+}
+
+.summaryText {
+  margin-top: 8px;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.45;
+}
+
+.summaryChips {
+  margin-top: 10px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.summaryChip {
+  display: inline-flex;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 12px;
+}
+
+.sectionBody {
+  margin-top: 14px;
+  display: grid;
+  gap: 14px;
+}
+
+.panelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.panelTitle {
+  font-size: 18px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.panelStep {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 1px solid rgba(169, 205, 246, 0.5);
+  background: rgba(169, 205, 246, 0.18);
+  color: #dcecff;
+  font-size: 12px;
+  font-weight: 800;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.badge {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #9fc7f2;
+  color: #101317;
+  font-size: 12px;
+  font-weight: 800;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.infoBox {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  padding: 16px;
+  text-align: center;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.75);
+  margin-bottom: 16px;
+}
+
+.primaryCta {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  background: #a9cdf6;
+  color: #0c1217;
+  border: none;
+  border-radius: 999px;
+  padding: 14px 16px;
+  font-size: 16px;
+  font-weight: 800;
+  cursor: pointer;
+  transition: 0.2s ease;
+}
+
+.primaryCta:hover {
+  filter: brightness(1.02);
+}
+
+.secondaryCta {
+  align-self: flex-start;
+  margin-top: 16px;
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.applicationPreview {
+  display: grid;
+  gap: 14px;
+}
+
+.previewLabel {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.65);
+  margin-bottom: 6px;
+}
+
+.previewValue {
+  font-size: 14px;
+  color: #f7f7f7;
+  line-height: 1.5;
+  white-space: pre-line;
+}
+
+.cartBox {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 14px;
+  margin-bottom: 16px;
+  min-height: 90px;
+}
+
+.panelLocked {
+  border-color: rgba(255, 255, 255, 0.1);
+  background: rgba(14, 14, 14, 0.66);
+}
+
+.lockNotice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.75);
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  padding: 10px 12px;
+  margin-bottom: 12px;
+}
+
+.lockAction {
+  border: 1px solid rgba(169, 205, 246, 0.6);
+  background: rgba(169, 205, 246, 0.2);
+  color: #deecff;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.cartEmpty {
+  text-align: center;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 13px;
+}
+
+.cartItems {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.cartItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-size: 13px;
+}
+
+.cartRemove {
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 16px;
+  cursor: pointer;
+}
+
+.clearButton {
+  background: rgba(255, 130, 130, 0.2);
+  color: #ffecec;
+  border: 1px solid rgba(255, 130, 130, 0.4);
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 12px;
+  cursor: pointer;
+  width: fit-content;
+}
+
+.applyButton {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  background: #a9cdf6;
+  color: #0c1217;
+  border: none;
+  border-radius: 999px;
+  padding: 14px 16px;
+  font-size: 15px;
+  font-weight: 800;
+  cursor: pointer;
+  transition: 0.2s ease;
+}
+
+.applyButton:not(:disabled):hover {
+  filter: brightness(1.02);
+}
+
+.applyButton:disabled {
+  background: rgba(169, 205, 246, 0.35);
+  color: rgba(12, 18, 23, 0.55);
+  cursor: not-allowed;
+}
+
+.projectsSection {
+  display: grid;
+  gap: 16px;
+}
+
+.projectFilterRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.projectFilterOptions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.projectTypeChip {
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.82);
+  padding: 3px 16px;
+  min-height: 32px;
+  min-width: 80px;
+  font-size: 14px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  touch-action: manipulation;
+  transition: border-color 0.18s ease, background-color 0.18s ease, box-shadow 0.18s ease,
+    transform 0.18s ease, color 0.18s ease;
+}
+
+.projectTypeChip:hover {
+  transform: translateY(-1px);
+}
+
+.projectTypeChip:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.4);
+  outline-offset: 2px;
+}
+
+.projectTypeChipAll {
+  border-color: rgba(255, 255, 255, 0.28);
+}
+
+.projectTypeChipWEB {
+  border-color: rgba(98, 183, 255, 0.45);
+  background: rgba(98, 183, 255, 0.14);
+}
+
+.projectTypeChipAPP {
+  border-color: rgba(106, 225, 180, 0.44);
+  background: rgba(106, 225, 180, 0.14);
+}
+
+.projectTypeChipGAME {
+  border-color: rgba(255, 193, 111, 0.45);
+  background: rgba(255, 193, 111, 0.15);
+}
+
+.projectTypeChipEMBEDDED {
+  border-color: rgba(176, 200, 235, 0.42);
+  background: rgba(176, 200, 235, 0.14);
+}
+
+.projectTypeChipActive {
+  border-color: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.3) inset, 0 8px 18px rgba(0, 0, 0, 0.28);
+  color: #ffffff;
+  transform: translateY(-1px);
+}
+
+.projectTypeChipWEB.projectTypeChipActive {
+  background: rgba(98, 183, 255, 0.32);
+  border-color: rgba(98, 183, 255, 0.85);
+  box-shadow: 0 0 0 1px rgba(98, 183, 255, 0.45) inset, 0 0 16px rgba(98, 183, 255, 0.35);
+}
+
+.projectTypeChipAPP.projectTypeChipActive {
+  background: rgba(106, 225, 180, 0.3);
+  border-color: rgba(106, 225, 180, 0.84);
+  box-shadow: 0 0 0 1px rgba(106, 225, 180, 0.44) inset, 0 0 16px rgba(106, 225, 180, 0.32);
+}
+
+.projectTypeChipGAME.projectTypeChipActive {
+  background: rgba(255, 193, 111, 0.34);
+  border-color: rgba(255, 193, 111, 0.88);
+  box-shadow: 0 0 0 1px rgba(255, 193, 111, 0.45) inset, 0 0 16px rgba(255, 193, 111, 0.3);
+}
+
+.projectTypeChipEMBEDDED.projectTypeChipActive {
+  background: rgba(176, 200, 235, 0.34);
+  border-color: rgba(176, 200, 235, 0.9);
+  box-shadow: 0 0 0 1px rgba(176, 200, 235, 0.46) inset, 0 0 16px rgba(176, 200, 235, 0.32);
+}
+
+.projectTypeChipAll.projectTypeChipActive {
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.projectsSectionHeader {
+  background: rgba(9, 13, 18, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  padding: 12px 14px;
+}
+
+.projectsTitleWrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.projectsTitle {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.projectsSubtitle {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.66);
+  margin-top: 3px;
+}
+
+.emptyProjects {
+  text-align: center;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 14px;
+  padding: 24px 0;
+}
+
+.projectCard {
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 22px;
+  padding: 18px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+}
+
+.projectSelected {
+  border-color: rgba(160, 210, 255, 0.7);
+  background: rgba(0, 0, 0, 0.7);
+}
+
+.projectLocked {
+  opacity: 0.8;
+}
+
+.projectHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.projectMetaRow {
+  margin-bottom: 8px;
+}
+
+.projectTypeTag {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.85);
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.projectTypeTagWEB {
+  border-color: rgba(98, 183, 255, 0.54);
+  background: rgba(98, 183, 255, 0.16);
+  color: #d8efff;
+}
+
+.projectTypeTagAPP {
+  border-color: rgba(106, 225, 180, 0.52);
+  background: rgba(106, 225, 180, 0.16);
+  color: #d8ffef;
+}
+
+.projectTypeTagGAME {
+  border-color: rgba(255, 193, 111, 0.54);
+  background: rgba(255, 193, 111, 0.18);
+  color: #ffeecf;
+}
+
+.projectTypeTagEMBEDDED {
+  border-color: rgba(176, 200, 235, 0.52);
+  background: rgba(176, 200, 235, 0.16);
+  color: #e2edff;
+}
+
+.projectTitle {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.projectCheck {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #8fd47a;
+  color: #0f151a;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 800;
+}
+
+.projectStateMuted {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.56);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  padding: 4px 8px;
+}
+
+.projectSummary {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.65);
+  margin-bottom: 12px;
+}
+
+.techStack {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.techTag {
+  background: rgba(255, 255, 255, 0.15);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.projectButton {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.8);
+  padding: 12px 14px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.projectButtonSelected {
+  background: rgba(130, 200, 120, 0.2);
+  border-color: rgba(130, 200, 120, 0.4);
+  color: #e7ffe7;
+}
+
+.projectButton:disabled {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.4);
+  cursor: not-allowed;
+}
+
+.floatingCart {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  background: #11171d;
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  font-weight: 800;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.35);
+  cursor: pointer;
+  z-index: 30;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.modalContent {
+  width: min(520px, 92vw);
+  background: #0d0d0f;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 24px;
+  padding: 22px;
+  color: #f7f7f7;
+  max-height: 86vh;
+  overflow-y: auto;
+  box-sizing: border-box;
+}
+
+.modalHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.modalTitle {
+  font-size: 20px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.modalSubtitle {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.modalClose {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: transparent;
+  color: #fff;
+  font-size: 18px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.formGroup {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.formGroup label {
+  font-size: 13px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.formGroup select,
+.formGroup textarea {
+  width: 100%;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: #15161a;
+  color: #f8f8f8;
+  padding: 12px 14px;
+  font-size: 14px;
+  box-sizing: border-box;
+}
+
+.formGroup select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding-right: 44px;
+  background-image: url("data:image/svg+xml,%3Csvg width='14' height='9' viewBox='0 0 14 9' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1.5L7 7.5L13 1.5' stroke='%23d9e2f1' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+  background-size: 14px 9px;
+}
+
+.formGroup select:focus,
+.formGroup select:focus-visible {
+  outline: none;
+  border-color: #9ed0ff;
+  box-shadow: 0 0 0 3px rgba(158, 208, 255, 0.16);
+}
+
+.formGroup textarea {
+  min-height: 140px;
+  resize: none;
+}
+
+.textareaError {
+  border-color: #ff7070;
+}
+
+.messageError {
+  font-size: 12px;
+  color: #ff7070;
+}
+
+.modalSubmit {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  background: #a9cdf6;
+  color: #0c1217;
+  border: none;
+  border-radius: 999px;
+  padding: 12px 14px;
+  font-size: 15px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.priorityGuide {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.75);
+  margin-bottom: 12px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.priorityList {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 18px;
+  display: grid;
+  gap: 10px;
+}
+
+.priorityListDragging {
+  gap: 12px;
+}
+
+.priorityListDragging .priorityItem {
+  transition: border-color 0.16s ease, background 0.16s ease, transform 0.16s ease, opacity 0.16s ease;
+}
+
+.priorityItem {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  cursor: grab;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.priorityItem:hover {
+  border-color: rgba(160, 210, 255, 0.7);
+  background: rgba(255, 255, 255, 0.12);
+  transform: translateY(-1px);
+}
+
+.dragging {
+  opacity: 0.6;
+  cursor: grabbing;
+}
+
+.dragOver {
+  border-color: rgba(168, 217, 255, 0.92);
+  background: rgba(166, 210, 250, 0.2);
+}
+
+.dropBefore::before,
+.dropAfter::after {
+  content: "";
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  height: 3px;
+  border-radius: 999px;
+  background: #9fc7f2;
+  box-shadow: 0 0 10px rgba(159, 199, 242, 0.6);
+}
+
+.dropBefore::before {
+  top: -2px;
+}
+
+.dropAfter::after {
+  bottom: -2px;
+}
+
+.priorityGhost {
+  cursor: default;
+  border: 1px dashed rgba(166, 210, 250, 0.95);
+  background: rgba(158, 201, 241, 0.14);
+  box-shadow: inset 0 0 0 1px rgba(166, 210, 250, 0.3);
+  animation: ghostPulse 1.1s ease-in-out infinite;
+}
+
+.priorityGhost .priorityNumber {
+  background: rgba(166, 210, 250, 0.25);
+  color: #dff0ff;
+}
+
+.priorityGhost .priorityTitle {
+  color: #d8ecff;
+}
+
+.priorityGhost .priorityRole {
+  color: rgba(210, 232, 255, 0.88);
+  font-weight: 700;
+}
+
+.priorityGhost .dragHandle {
+  opacity: 0.18;
+}
+
+@keyframes ghostPulse {
+  0%,
+  100% {
+    background: rgba(158, 201, 241, 0.12);
+    border-color: rgba(166, 210, 250, 0.75);
+  }
+  50% {
+    background: rgba(158, 201, 241, 0.2);
+    border-color: rgba(185, 223, 255, 1);
+  }
+}
+
+.priorityNumber {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: #11171d;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 800;
+}
+
+.priorityInfo {
+  flex: 1;
+}
+
+.priorityTitle {
+  font-weight: 700;
+}
+
+.priorityRole {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.dragHandle {
+  font-size: 18px;
+  color: rgba(255, 255, 255, 0.4);
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.priorityItem:hover .dragHandle {
+  color: rgba(255, 255, 255, 0.85);
+  transform: scale(1.05);
+}
+
+.errorCard {
+  margin-top: 120px;
+  background: rgba(0, 0, 0, 0.65);
+  border-radius: 20px;
+  padding: 24px;
+  text-align: center;
+}
+
+.errorTitle {
+  font-size: 18px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.errorMessage {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.65);
+  margin-bottom: 16px;
+}
+
+.appliedCard {
+  max-width: 520px;
+  margin: 120px auto 0;
+  background: rgba(0, 0, 0, 0.6);
+  border-radius: 20px;
+  padding: 32px 24px;
+  text-align: center;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.appliedCard h1 {
+  font-size: 22px;
+  margin-bottom: 12px;
+}
+
+.appliedCard p {
+  color: rgba(255, 255, 255, 0.65);
+  margin-bottom: 20px;
+}
+
+.primaryButton {
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: none;
+  background: #a9cdf6;
+  color: #0c1217;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+@media (max-width: 640px) {
+  .stepGuide {
+    grid-template-columns: 1fr;
+  }
+
+  .stepDivider {
+    display: none;
+  }
+
+  .editableHeader {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .editableTitleWrap {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .editButton {
+    align-self: flex-start;
+  }
+
+  .lockNotice {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .projectFilterRow {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .projectFilterOptions {
+    gap: 10px;
+  }
+
+  .projectTypeChip {
+    min-height: 34px;
+    min-width: 84px;
+    padding: 4px 16px;
+    font-size: 14px;
+  }
+
+  .heroTitle {
+    font-size: 26px;
+  }
+
+  .panel {
+    padding: 20px 16px;
+  }
+
+  .floatingCart {
+    right: 18px;
+    bottom: 18px;
+  }
+}
+
+.myApplicationList {
+  display: grid;
+  gap: 0;
+  margin-top: 18px;
+}
+
+.myApplicationItem {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 13px;
+  color: inherit;
+  font-size: 14px;
+}
+
+.myApplicationItem + .myApplicationItem {
+  border-top: 0;
+}
+
+.myApplicationItem + .myApplicationItem::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 13px;
+  left: 13px;
+  border-top: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.myApplicationItem strong { color: inherit; }
+
+.myApplicationName {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+}
+
+.myApplicationPriorityNumber {
+  flex-shrink: 0;
+  align-self: center;
+  background: transparent;
+  color: #9ed0ff;
+  font-weight: 800;
+}
+
+.cancelApplicationButton {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 22px;
+  font-weight: 400;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.cancelApplicationButton:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #ffffff;
+}
+
+.cancelApplicationButton:focus-visible {
+  outline: 2px solid rgba(169, 205, 246, 0.8);
+  outline-offset: 2px;
+}
+
+.availableSection {
+  margin: 28px 0 18px;
+  padding: 24px 0 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  background: transparent;
+}
+
+.availableHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.availableHeader h2 { margin: 5px 13px 6px; font-size: 20px; }
+.availableHeader p { margin: 0; color: rgba(255,255,255,.62); font-size: 13px; }
+.availableProjectList { display: grid; gap: 14px; }
+
+.applicationProjectCard {
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  padding: 19px;
+  border: 1px solid rgba(255,255,255,.13);
+  border-radius: 20px;
+  background: rgba(0, 0, 0, 0.502);
+  transition: border-color .2s ease, background .2s ease;
+}
+
+.applicationProjectTop { display: flex; justify-content: space-between; gap: 14px; }
+.applicationProjectTop h3 { margin: 0 0 7px; font-size: 20px; }
+.applicationProjectTop p { margin: 0; color: rgba(255,255,255,.63); font-size: 13px; }
+.applicationProjectTitleRow {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-bottom: 7px;
+}
+.applicationProjectTitleRow h3 { margin: 0; }
+.appliedMark { color: #9ed0ff; font-size: 12px; font-weight: 800; white-space: nowrap; }
+.recruitBlock {
+  margin: 17px 0;
+}
+.recruitPositions { display: flex; flex-wrap: wrap; gap: 5px; }
+
+.projectRequirements {
+  margin-top: 12px;
+  padding: 13px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.045);
+}
+
+.projectRequirements p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.76);
+  font-size: 13px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.projectTeamBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  padding: 5px 7px;
+  /* border: 1px solid currentColor; */
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.projectTeamBadgeWEB {
+  background: rgba(158, 208, 255, 0.078);
+  color: #9ed0ff90;
+}
+
+.projectTeamBadgeAPP {
+  background: rgba(255, 132, 132, 0.084);
+  color: #ffaaaa85;
+}
+
+.projectTeamBadgeGAME{
+  background: rgba(118, 218, 156, 0.087);
+  color: #8de3ae7b;
+}
+
+.projectTeamBadgeOTHER,
+.projectTeamBadgeEMBEDDED {
+  background: rgba(255, 210, 105, 0.057);
+  color: #ffd2697a;
+}
+
+.recruitPosition {
+  padding: 6px 11px;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(255,255,255,.08);
+  color: rgba(255,255,255,.75);
+  font-size: 12px;
+}
+
+.recruitPositionApplied {
+  background: rgba(171, 212, 253, 0.2);
+  color: #dcefff;
+}
+
+.applicationActions {
+  width: 100%;
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 9px;
+}
+
+.writeApplicationButton, .modifyApplicationButton, .addApplicationButton {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 15px 14px;
+  border-radius: 17px;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.4;
+  text-align: center;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  cursor: pointer;
+  transition: background-color .2s ease, border-color .2s ease, color .2s ease;
+}
+
+.modifyApplicationButton {
+  border: 1px solid #ABD4FD;
+  background: rgba(171, 212, 253, 0.2);
+  color: #dcefff;
+}
+
+.finalSubmitButton {
+  margin-top: 20px;
+}
+
+.writeApplicationButton, .addApplicationButton {
+  border: 1px solid rgba(159, 162, 165, 0.55);
+  background: rgba(245, 250, 255, 0.1);
+  color: #aeababaf;
+}
+
+.modifyApplicationButton:hover {
+  border-color: #c7e3ff;
+  background: rgba(171, 212, 253, 0.32);
+}
+
+.writeApplicationButton:not(:disabled):hover,
+.addApplicationButton:not(:disabled):hover {
+  border-color: rgba(220, 224, 228, 0.8);
+  background: rgba(245, 250, 255, 0.18);
+  color: rgba(255, 255, 255, 0.86);
+}
+
+.writeApplicationButton:disabled, .addApplicationButton:disabled {
+  opacity: .4;
+  cursor: not-allowed;
+}
+
+.existingFormLabel {
+  margin: 28px 4px 10px;
+  color: rgba(255,255,255,.58);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.applicationModal {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(0,0,0,.72);
+}
+
+.applicationModalContent {
+  position: relative;
+  width: min(520px, 100%);
+  box-sizing: border-box;
+  padding: 28px;
+  border: 1px solid rgba(158,205,250,.35);
+  border-radius: 24px;
+  background: #11151a;
+  box-shadow: 0 28px 80px rgba(0,0,0,.65);
+}
+
+.applicationModalContent h2 { margin: 0 42px 7px 0; font-size: 22px; }
+.applicationModalDescription { margin: 0 0 22px; color: rgba(255,255,255,.62); font-size: 13px; }
+.applicationModalClose {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  width: 32px;
+  height: 32px;
+  border: 1px solid rgba(255,255,255,.2);
+  border-radius: 50%;
+  background: rgba(255,255,255,.08);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.characterCount { margin-top: 6px; text-align: right; color: rgba(255,255,255,.48); font-size: 11px; }
+
+.cancelModalContent {
+  width: min(420px, 100%);
+  border-color: #ffffff51;
+  background: #ffffff11;
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  text-align: center;
+}
+
+.cancelModalContent h2 { margin: 0 0 14px; font-size: 19px; font-weight: 600; }
+.cancelModalContent > .applicationModalClose + h2 { margin-right: 38px; margin-left: 38px; }
+
+.cancelModalDescription {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 14px;
+}
+
+.cancelWarning {
+  margin: 8px 0 22px;
+  color: rgba(255,255,255,.5);
+  font-size: 12px;
+}
+
+.submitApplicationList {
+  display: grid;
+  gap: 0;
+  margin: 0 0 14px;
+  padding: 0;
+  list-style: none;
+  text-align: left;
+}
+
+.submitPrimaryPosition {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 6px;
+  margin: 8px 0 2px;
+  padding: 12px 2px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.16);
+  font-size: 13px;
+}
+
+.submitPrimaryPosition span {
+  color: rgba(255, 255, 255, 0.58);
+}
+
+.submitPrimaryPosition strong {
+  color: rgba(255, 255, 255, 0.88);
+  font-weight: 700;
+}
+
+.submitModalContent {
+  text-align: left;
+}
+
+.submitModalContent h2 {
+  margin-bottom: 14px;
+  color: #b8dcff;
+  font-size: 19px;
+  text-align: center;
+}
+
+.submitModalContent .confirmSubmitButton {
+  text-align: center;
+}
+
+.submitModalContent .submitApplicationList li {
+  justify-content: flex-start;
+  padding: 9px 2px;
+}
+
+.submitModalContent .submitApplicationPriority {
+  color: rgba(255, 255, 255, 0.48);
+}
+
+.submitApplicationList li {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+  padding: 10px 0;
+  font-size: 14px;
+}
+
+.submitApplicationPriority {
+  flex-shrink: 0;
+  color: #9ed0ff;
+  font-weight: 800;
+}
+.submitApplicationProject {
+  color: #ffffff;
+  font-weight: 700;
+}
+.submitApplicationPosition {
+  color: rgba(255, 255, 255, 0.72);
+  font-weight: 400;
+}
+
+.cancelModalActions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  width: 100%;
+  min-width: 0;
+  gap: 10px;
+}
+.submitModalActions { grid-template-columns: 1fr; }
+.keepApplicationButton, .confirmCancelButton {
+  padding: 12px 14px;
+  border-radius: 12px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.keepApplicationButton {
+  border: 1px solid rgba(255,255,255,.2);
+  background: rgba(255,255,255,.08);
+  color: #fff;
+}
+
+.confirmCancelButton {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 48px;
+  border: 1px solid #9ed0ff;
+  background: #9ed0ff;
+  color: #000000;
+  font-size: 15px;
+  font-weight: 700;
+  transition: background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+}
+
+.confirmCancelButton:hover {
+  background: #b5dcff;
+  border-color: #b5dcff;
+}
+
+.confirmSubmitButton {
+  border-color: rgba(169, 205, 246, .65);
+  background: rgba(169, 205, 246, .24);
+  color: #dcecff;
+}
+
+.confirmSubmitButton:not(:disabled):hover {
+  border-color: rgba(169, 205, 246, 0.82);
+  background: rgba(169, 205, 246, 0.34);
+  color: #ffffff;
+}
+
+.confirmSubmitButton:disabled,
+.confirmSubmitButton:disabled:hover {
+  border-color: rgba(169, 205, 246, 0.45);
+  background: rgba(169, 205, 246, 0.18);
+  color: rgba(220, 236, 255, 0.65);
+  cursor: wait;
+}
+
+@media (max-width: 640px) {
+  .availableHeader { flex-direction: column; }
+  .availableSection { padding: 20px 0 0; }
+  .applicationModalContent { padding: 24px 18px; }
+  .myApplicationItem { align-items: center; }
+  .myApplicationName { align-items: center; flex-wrap: wrap; }
+}

--- a/client/src/assets/TeamBuildApply2nd.module.css
+++ b/client/src/assets/TeamBuildApply2nd.module.css
@@ -1529,6 +1529,7 @@
 }
 
 .applicationProjectTop { display: flex; justify-content: space-between; gap: 14px; }
+.applicationProjectInfo { min-width: 0; flex: 1; }
 .applicationProjectTop h3 { margin: 0 0 7px; font-size: 20px; }
 .applicationProjectTop p { margin: 0; color: rgba(255,255,255,.63); font-size: 13px; }
 .applicationProjectTitleRow {
@@ -1539,6 +1540,13 @@
   margin-bottom: 7px;
 }
 .applicationProjectTitleRow h3 { margin: 0; }
+.recruitCount {
+  margin-left: auto;
+  color: rgba(255, 255, 255, 0.406);
+  font-size: 13px;
+  font-weight: 400;
+  white-space: nowrap;
+}
 .appliedMark { color: #9ed0ff; font-size: 12px; font-weight: 800; white-space: nowrap; }
 .recruitBlock {
   margin: 17px 0;

--- a/client/src/pages/TeamBuildApplyPage.js
+++ b/client/src/pages/TeamBuildApplyPage.js
@@ -195,36 +195,36 @@ function TeamBuildApplyPage() {
   // }, []);
 
   useEffect(() => {
-  setHasApplied(false);
+    setHasApplied(false);
 
-  setProjects([
-      {
-        projectId: 1,
-        title: "프로젝트 1",
-        projectType: "WEB",
-        summary: "사용자 경험을 혁신하는 웹 플랫폼 개발 프로젝트입니다.",
-        techStack: ["React", "JavaScript"],
-        recruitPositions: ["FRONTEND", "BACKEND", "DESIGN"],
-      },
-      {
-        projectId: 2,
-        title: "프로젝트 2",
-        projectType: "APP",
-        summary: "데이터 기반 서비스를 구축하는 프로젝트입니다.",
-        techStack: ["React Native", "Spring"],
-        recruitPositions: ["APP", "BACKEND", "DESIGN"],
-      },
-      {
-        projectId: 3,
-        title: "프로젝트 3",
-        projectType: "GAME",
-        summary: "새로운 게임 서비스를 개발하는 프로젝트입니다.",
-        techStack: ["Unity", "C#"],
-        recruitPositions: ["GAME", "BACKEND", "DESIGN"],
-      },
-    ]);
+    setProjects([
+        {
+          projectId: 1,
+          title: "프로젝트 1",
+          projectType: "WEB",
+          summary: "사용자 경험을 혁신하는 웹 플랫폼 개발 프로젝트입니다.",
+          techStack: ["React", "JavaScript"],
+          recruitPositions: ["FRONTEND", "BACKEND", "DESIGN"],
+        },
+        {
+          projectId: 2,
+          title: "프로젝트 2",
+          projectType: "APP",
+          summary: "데이터 기반 서비스를 구축하는 프로젝트입니다.",
+          techStack: ["React Native", "Spring"],
+          recruitPositions: ["APP", "BACKEND", "DESIGN"],
+        },
+        {
+          projectId: 3,
+          title: "프로젝트 3",
+          projectType: "GAME",
+          summary: "새로운 게임 서비스를 개발하는 프로젝트입니다.",
+          techStack: ["Unity", "C#"],
+          recruitPositions: ["GAME", "BACKEND", "DESIGN"],
+        },
+      ]);
 
-    setIsLoading(false);
+      setIsLoading(false);
   }, []);
   // 나중에 제거하기. 임시 내용
 

--- a/client/src/pages/TeamBuildApplyPage2nd.js
+++ b/client/src/pages/TeamBuildApplyPage2nd.js
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { teamBuildApi } from "../api/team-build";
 import LoadingPage from "../components/LoadingPage";
 import wapsLogo from "../assets/img/waps_logo.png";
-import styles from "../assets/TeamBuildApply.module.css";
+import styles from "../assets/TeamBuildApply2nd.module.css";
 import noticeIcon from "../assets/img/noticeIcon.svg";
 import noticeArrow from "../assets/img/noticeArrow.svg";
 import emptyFolder from "../assets/img/folder.svg";
@@ -18,17 +18,6 @@ const POSITION_OPTIONS = [
   { value: "APP", label: "앱" },
   { value: "GAME", label: "게임" },
   { value: "EMBEDDED", label: "임베디드" },
-];
-
-const PRIMARY_POSITION_OPTIONS = [
-  { value: "BACKEND", label: "백엔드" },
-  { value: "FRONTEND", label: "프론트엔드" },
-  { value: "DESIGN", label: "디자이너" },
-  { value: "GAME", label: "게임" },
-  { value: "APP", label: "앱" },
-  { value: "EMBEDDED", label: "임베디드" },
-  { value: "AI", label: "AI" },
-  { value: "OTHER", label: "기타" },
 ];
 
 const POSITION_LABELS = POSITION_OPTIONS.reduce((acc, item) => {
@@ -120,7 +109,7 @@ const calculateDropInsertIndex = (projectIds, movingId, targetId, placement = "b
   return placement === "after" ? targetIndex + 1 : targetIndex;
 };
 
-function TeamBuildApplyPage() {
+function TeamBuildApplyPage2nd() {
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState("");
@@ -147,8 +136,6 @@ function TeamBuildApplyPage() {
   const [applicationDraggingId, setApplicationDraggingId] = useState(null);
   const [applicationDragOverId, setApplicationDragOverId] = useState(null);
   const [applicationDragOverPlacement, setApplicationDragOverPlacement] = useState("before");
-  const [primaryPosition, setPrimaryPosition] = useState("");
-  //추가한 내용
 
   // useEffect(() => {
   //   const token = Cookies.get("authToken") || window.localStorage.getItem("authToken") || "";
@@ -205,6 +192,7 @@ function TeamBuildApplyPage() {
         summary: "사용자 경험을 혁신하는 웹 플랫폼 개발 프로젝트입니다.",
         techStack: ["React", "JavaScript"],
         recruitPositions: ["FRONTEND", "BACKEND", "DESIGN"],
+        requirements: "주 1회 팀 회의에 참여할 수 있고, 적극적으로 소통하실 분을 찾습니다.",
       },
       {
         projectId: 2,
@@ -213,6 +201,7 @@ function TeamBuildApplyPage() {
         summary: "데이터 기반 서비스를 구축하는 프로젝트입니다.",
         techStack: ["React Native", "Spring"],
         recruitPositions: ["APP", "BACKEND", "DESIGN"],
+        requirements: "앱 서비스 개발 경험이 있거나 새로운 기술을 배우는 데 관심 있는 분을 환영합니다.",
       },
       {
         projectId: 3,
@@ -221,6 +210,7 @@ function TeamBuildApplyPage() {
         summary: "새로운 게임 서비스를 개발하는 프로젝트입니다.",
         techStack: ["Unity", "C#"],
         recruitPositions: ["GAME", "BACKEND", "DESIGN"],
+        requirements: "Unity 기반 협업이 가능하고 게임 기획에 관심 있는 분을 찾습니다.",
       },
     ]);
 
@@ -278,9 +268,6 @@ function TeamBuildApplyPage() {
   const isAllProjectTypes = selectedProjectTypes.length === 0;
 
   const getPositionLabel = (value) => POSITION_LABELS[value] || value;
-  const getPrimaryPositionLabel = (value) =>
-    PRIMARY_POSITION_OPTIONS.find((option) => option.value === value)?.label || "미선택";
-
   const getProjectTeamLabel = (project) => {
     const projectType = getProjectTeamType(readProjectType(project));
     const teamNumber = projects
@@ -329,7 +316,11 @@ function TeamBuildApplyPage() {
     if (application) {
       setProjectApplications((prev) => prev.map((item) =>
         item.id === application.id
-          ? { ...item, position: projectFormPosition, message: projectFormMessage.trim() }
+          ? {
+              ...item,
+              position: projectFormPosition,
+              message: projectFormMessage.trim(),
+            }
           : item
       ));
     } else {
@@ -392,16 +383,12 @@ function TeamBuildApplyPage() {
 
   const submitProjectApplications = async () => {
     if (projectApplications.length < 3) return;
-    if (!primaryPosition) {
-      alert("주요 직무를 선택해주세요.");
-      return;
-    }
 
     setIsSubmitConfirmOpen(true);
   };
 
   const confirmProjectApplications = async () => {
-    if (projectApplications.length < 3 || !primaryPosition || isSubmitting) return;
+    if (projectApplications.length < 3 || isSubmitting) return;
 
     const applies = projectApplications.map((application) => ({
       projectId: application.projectId,
@@ -718,7 +705,7 @@ function TeamBuildApplyPage() {
         </div>
 
         <div className={styles.hero}>
-          <div className={styles.heroTitle}>TEAM BUILDING_1ST</div>
+          <div className={styles.heroTitle}>TEAM BUILDING_2ND</div>
           <div className={styles.heroSubtitle}>
             함께할 팀을 찾고, 원하는 프로젝트에 도전해보세요
           </div>
@@ -736,7 +723,7 @@ function TeamBuildApplyPage() {
                 alt=""
                 className={styles.noticeIcon}
               />
-              <span>팀빌딩 안내사항</span>
+              <span>2차 팀빌딩 안내사항</span>
             </div>
 
             <span
@@ -774,28 +761,6 @@ function TeamBuildApplyPage() {
               <p>(우선순위는 드래그로 조정이 가능합니다)</p>
             </div>
           </div>
-
-          <section className={styles.primaryPositionCard} aria-labelledby="primary-position-title">
-            <div className={styles.primaryPositionHeader}>
-              <h2 id="primary-position-title">주요 직무</h2>
-              <p>주요직무는 1차 팀빌딩에는 영향을 끼치지 않으며, 2·3차 팀빌딩시 사용될 예정입니다</p>
-            </div>
-            <div className={`${styles.formGroup} ${styles.primaryPositionSelect}`}>
-              <select
-                id="primaryPosition"
-                aria-label="주요 직무"
-                value={primaryPosition}
-                onChange={(event) => setPrimaryPosition(event.target.value)}
-              >
-                <option value="">직무를 선택해주세요</option>
-                {PRIMARY_POSITION_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </section>
 
           {projectApplications.length === 0 ? (
             <div className={styles.emptyApply}>
@@ -909,6 +874,12 @@ function TeamBuildApplyPage() {
                           {getPositionLabel(position)}
                         </span>
                       ))}
+                    </div>
+                    <div className={styles.projectRequirements}>
+                      <p>
+                        {project.requirements || project.requirement || project.condition ||
+                          "등록된 요청 조건이 없습니다."}
+                      </p>
                     </div>
                   </div>
                   <div className={styles.applicationActions}>
@@ -1047,10 +1018,6 @@ function TeamBuildApplyPage() {
               ×
             </button>
             <h2 id="submit-application-title">최종 제출을 진행하시겠습니까?</h2>
-            <div className={styles.submitPrimaryPosition}>
-              <span>주요 직무</span>
-              <strong>{getPrimaryPositionLabel(primaryPosition)}</strong>
-            </div>
             <ol id="submit-application-description" className={styles.submitApplicationList}>
               {projectApplications.map((application, index) => (
                 <li key={application.id}>
@@ -1081,4 +1048,4 @@ function TeamBuildApplyPage() {
   );
 }
 
-export default TeamBuildApplyPage;
+export default TeamBuildApplyPage2nd;

--- a/client/src/pages/TeamBuildApplyPage2nd.js
+++ b/client/src/pages/TeamBuildApplyPage2nd.js
@@ -719,6 +719,8 @@ function TeamBuildApplyPage2nd() {
             type="button"
             className={styles.noticeButton}
             onClick={() => setIsNoticeOpen(!isNoticeOpen)}
+            aria-expanded={isNoticeOpen}
+            aria-controls="notice-content"
           >
             <div className={styles.noticeTitle}>
               <img

--- a/client/src/pages/TeamBuildApplyPage2nd.js
+++ b/client/src/pages/TeamBuildApplyPage2nd.js
@@ -192,6 +192,7 @@ function TeamBuildApplyPage2nd() {
         summary: "사용자 경험을 혁신하는 웹 플랫폼 개발 프로젝트입니다.",
         techStack: ["React", "JavaScript"],
         recruitPositions: ["FRONTEND", "BACKEND", "DESIGN"],
+        recruitCount: 3,
         requirements: "주 1회 팀 회의에 참여할 수 있고, 적극적으로 소통하실 분을 찾습니다.",
       },
       {
@@ -201,6 +202,7 @@ function TeamBuildApplyPage2nd() {
         summary: "데이터 기반 서비스를 구축하는 프로젝트입니다.",
         techStack: ["React Native", "Spring"],
         recruitPositions: ["APP", "BACKEND", "DESIGN"],
+        recruitCount: 2,
         requirements: "앱 서비스 개발 경험이 있거나 새로운 기술을 배우는 데 관심 있는 분을 환영합니다.",
       },
       {
@@ -210,6 +212,7 @@ function TeamBuildApplyPage2nd() {
         summary: "새로운 게임 서비스를 개발하는 프로젝트입니다.",
         techStack: ["Unity", "C#"],
         recruitPositions: ["GAME", "BACKEND", "DESIGN"],
+        recruitCount: 4,
         requirements: "Unity 기반 협업이 가능하고 게임 기획에 관심 있는 분을 찾습니다.",
       },
     ]);
@@ -737,8 +740,7 @@ function TeamBuildApplyPage2nd() {
 
           {isNoticeOpen && (
             <div className={styles.noticeContent}>
-              <p>• 이번 팀빌딩은 총 3차에 걸쳐 진행됩니다.</p>
-              <p>• 지원서는 최소 3개 - 최대 5개까지 지원할 수 있으며, 동일 프로젝트에도 서로 다른 직무로 지원할 수 있습니다.</p>
+              <p>• 2차 팀빌딩도 마찬가지로 최소 3개 - 최대 5개까지 지원할 수 있으며, 동일 프로젝트에도 서로 다른 직무로 지원할 수 있습니다.</p>
             </div>
           )}
         </div>
@@ -846,7 +848,7 @@ function TeamBuildApplyPage2nd() {
                   className={styles.applicationProjectCard}
                 >
                   <div className={styles.applicationProjectTop}>
-                    <div>
+                    <div className={styles.applicationProjectInfo}>
                       <div className={styles.applicationProjectTitleRow}>
                         <h3>{project.title}</h3>
                         <span
@@ -855,6 +857,9 @@ function TeamBuildApplyPage2nd() {
                           }`}
                         >
                           {getProjectTeamLabel(project)}
+                        </span>
+                        <span className={styles.recruitCount}>
+                          모집인원 : {project.recruitCount ?? 0}명
                         </span>
                       </div>
                       <p>{project.summary}</p>


### PR DESCRIPTION
<!--
1. PR 이름 컨벤션
feat: 투표 상태 관리에 필요한 api 개발

2. 라벨
작업 분야: server/client
작업 종류: feat/refactor/fix/...
    이름: 가나다/가나디/기니디/...
-->

##  📌 관련 이슈
- #604 
- 팀빌딩 방식 변경에 따른 2차 팀빌딩 페이지 구현했습니다.

## ✨ PR 세부 내용
<!-- 수정/추가한 내용을 적어주세요. -->
## 1차와 다른 UI
- 우측 상단에 2차 팀빌딩시 프로젝트별 모집 인원을 추가할 수 있는 칸을 만들었습니다.
- 프로젝트 희망 인원의 조건을 적을 수 있는 조건란도 추가하였습니다.<br>
<img width="380" height="253" alt="image" src="https://github.com/user-attachments/assets/972be7be-e02c-4ba7-b89c-85b40a28a6c3" /><br><br>
- 내 지원서란에 주요직무를 제거했습니다.
- 2차 팀빌딩 안내사항 내용을 변경하였습니다.



## 👀 확인해주세요!


## ⌛ 소요 시간
