### PR TITLE
feat: 팀 빌딩 서버 로직 수정

### DIFF
--- a/server/src/main/java/wap/web2/server/admin/entity/TeamBuildingMeta.java
+++ b/server/src/main/java/wap/web2/server/admin/entity/TeamBuildingMeta.java
@@ -21,6 +21,35 @@ public class TeamBuildingMeta {
         this.semester = semester;
     }
 
+    public TeamBuildingMeta(Long id, String semester, TeamBuildingStatus status) {
+        this.id = id;
+        this.semester = semester;
+        this.status = status;
+    }
+
+    @Column(nullable = false)
+    private int round = 1;
+
+    @Column(nullable = false)
+    private int completedRound = 0;
+
+    public void changeStatus(TeamBuildingStatus next) {
+        if (next == TeamBuildingStatus.APPLY && status == TeamBuildingStatus.CLOSED
+            && completedRound == round) {
+            if (round >= 2) {
+                throw new wap.web2.server.exception.ConflictException("지원 방식의 팀빌딩은 2차까지 진행할 수 있습니다.");
+            }
+            round++;
+        } else if (next != TeamBuildingStatus.CLOSED && completedRound >= round) {
+            throw new wap.web2.server.exception.ConflictException("완료된 차수는 다시 진행할 수 없습니다.");
+        }
+        this.status = next;
+    }
+
+    public void completeRound() {
+        completedRound = round;
+    }
+
     @Id
     @Column
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/server/src/main/java/wap/web2/server/admin/entity/TeamBuildingMeta.java
+++ b/server/src/main/java/wap/web2/server/admin/entity/TeamBuildingMeta.java
@@ -46,6 +46,11 @@ public class TeamBuildingMeta {
         this.status = next;
     }
 
+    public void completeThirdRound() {
+        round = 3;
+        completedRound = 3;
+    }
+
     public void completeRound() {
         completedRound = round;
     }

--- a/server/src/main/java/wap/web2/server/admin/repository/TeamBuildingMetaRepository.java
+++ b/server/src/main/java/wap/web2/server/admin/repository/TeamBuildingMetaRepository.java
@@ -1,6 +1,8 @@
 package wap.web2.server.admin.repository;
 
 import java.util.Optional;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -15,6 +17,10 @@ public interface TeamBuildingMetaRepository extends JpaRepository<TeamBuildingMe
         @Param("semester") String semester,
         @Param("status") TeamBuildingStatus status
     );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT t FROM TeamBuildingMeta t WHERE t.semester = :semester")
+    Optional<TeamBuildingMeta> findBySemesterForUpdate(@Param("semester") String semester);
 
     Optional<TeamBuildingMeta> findBySemester(String semester);
 

--- a/server/src/main/java/wap/web2/server/admin/service/AdminTeamBuildingService.java
+++ b/server/src/main/java/wap/web2/server/admin/service/AdminTeamBuildingService.java
@@ -1,68 +1,42 @@
 package wap.web2.server.admin.service;
 
 import static wap.web2.server.util.SemesterGenerator.generateSemester;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wap.web2.server.admin.dto.request.TeamBuildingStatusRequest;
-import wap.web2.server.admin.entity.TeamBuildingMeta;
-import wap.web2.server.admin.entity.TeamBuildingStatus;
+import wap.web2.server.admin.entity.*;
 import wap.web2.server.admin.repository.TeamBuildingMetaRepository;
-import wap.web2.server.exception.ConflictException;
-import wap.web2.server.exception.ResourceNotFoundException;
+import wap.web2.server.exception.*;
 import wap.web2.server.project.entity.Project;
 import wap.web2.server.project.repository.ProjectRepository;
-import wap.web2.server.teambuild.dto.ApplyInfo;
-import wap.web2.server.teambuild.dto.RecruitInfo;
-import wap.web2.server.teambuild.entity.Position;
-import wap.web2.server.teambuild.entity.ProjectApply;
-import wap.web2.server.teambuild.entity.ProjectRecruit;
-import wap.web2.server.teambuild.entity.ProjectRecruitWish;
-import wap.web2.server.teambuild.entity.Team;
-import wap.web2.server.teambuild.repository.ProjectApplyRepository;
-import wap.web2.server.teambuild.repository.ProjectRecruitRepository;
-import wap.web2.server.teambuild.repository.TeamRepository;
-import wap.web2.server.teambuild.service.TeamBuilder;
+import wap.web2.server.teambuild.entity.*;
+import wap.web2.server.teambuild.repository.*;
+import wap.web2.server.teambuild.service.PositionTeamBuilder;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AdminTeamBuildingService {
-
     private final TeamBuildingMetaRepository teamBuildingMetaRepository;
     private final ProjectRecruitRepository recruitRepository;
     private final ProjectApplyRepository applyRepository;
     private final ProjectRepository projectRepository;
     private final TeamRepository teamRepository;
-    private final TeamBuilder teamBuilder;
+    private final PositionTeamBuilder teamBuilder;
 
     @Transactional(readOnly = true)
     public TeamBuildingStatus getStatus() {
-        TeamBuildingMeta currentMeta = findCurrentMeta();
-        return currentMeta.getStatus();
+        return teamBuildingMetaRepository.findBySemester(generateSemester())
+            .orElseThrow(() -> new ConflictException("현재 학기의 팀빌딩이 초기화되지 않았습니다.")).getStatus();
     }
 
     @Transactional
-    public void changeStatus(TeamBuildingStatusRequest statusRequest) {
-        String semester = statusRequest.semester();
-        TeamBuildingStatus status = statusRequest.status();
-        int updated = teamBuildingMetaRepository.updateTeamBuildingMetaStatus(semester, status);
-        if (updated == 0) {
-            throw new ResourceNotFoundException(
-                String.format("%s 학기의 팀빌딩을 찾을 수 없습니다.", semester)
-            );
-        }
+    public void changeStatus(TeamBuildingStatusRequest request) {
+        if (request.status() == null) throw new BadRequestException("팀빌딩 상태가 필요합니다.");
+        TeamBuildingMeta meta = teamBuildingMetaRepository.findBySemesterForUpdate(request.semester())
+            .orElseThrow(() -> new ResourceNotFoundException("해당 학기의 팀빌딩을 찾을 수 없습니다."));
+        meta.changeStatus(request.status());
     }
 
     @Transactional
@@ -70,180 +44,31 @@ public class AdminTeamBuildingService {
         if (teamBuildingMetaRepository.existsTeamBuildingMetaBySemester(semester)) {
             throw new ConflictException("해당 학기의 팀빌딩이 이미 생성되었습니다.");
         }
-
-        TeamBuildingMeta teamBuildingMeta = new TeamBuildingMeta(semester);
-        teamBuildingMetaRepository.save(teamBuildingMeta);
+        teamBuildingMetaRepository.save(new TeamBuildingMeta(semester));
     }
 
     @Transactional
     public void makeTeam() {
-        TeamBuildingMeta current = findCurrentMeta();
-        validateTeamBuildingStatus(current);
-
-        // 이번학기 모든 프로젝트
-        List<Project> projects = projectRepository.findProjectsBySemester(generateSemester());
-
-        // Map<projectId, Map<position, Set<userId>>>
-        Map<Long, Map<Position, Set<Long>>> results = new HashMap<>();
-        for (Position position : Position.values()) {
-            // Map<userId, List<ApplyInfo>>
-            Map<Long, List<ApplyInfo>> applyMap = getApplies(position);
-            if (applyMap.isEmpty()) {
-                continue;
-            }
-            // Map<projectId, RecruitInfo>
-            Map<Long, RecruitInfo> recruitMap = getRecruits(position, projects);
-            if (recruitMap.isEmpty()) {
-                continue;
-            }
-
-            log.info("team-build-position:{} \ttry", position);
-            Map<Long, Set<Long>> allocated = teamBuilder.allocate(applyMap, recruitMap);
-            log.info("team-build-position:{} \tsuccess", position);
-
-            // Map<projectId, Set<userId>> -> Map<projectId, Map<position, Set<userId>>>
-            for (Map.Entry<Long, Set<Long>> entry : allocated.entrySet()) {
-                long projectId = entry.getKey();
-                Set<Long> userIds = entry.getValue();
-
-                // 프로젝트별 Position Map (EnumMap 메모리/성능 유리)
-                Map<Position, Set<Long>> byPosition = results.computeIfAbsent(projectId, k ->
-                    new EnumMap<>(Position.class)
-                );
-
-                // 해당 포지션의 Member Set
-                Set<Long> members = byPosition.computeIfAbsent(position, k -> new HashSet<>());
-                members.addAll(userIds);
-            }
-        }
-
-        saveTeamBuildingResults(results);
-    }
-
-    // TODO: 내부 객체에 position 빼기
-    private Map<Long, List<ApplyInfo>> getApplies(Position pos) {
-        List<ProjectApply> applyEntities = applyRepository.findAllBySemesterAndRoundAndPosition(
-            generateSemester(),
-            1, // 기존 관리자 배정은 1차 데이터만 사용한다.
-            pos
-        );
-        if (applyEntities.isEmpty()) {
-            return Collections.emptyMap();
-        }
-
-        Map<Long, List<ApplyInfo>> applyMap = new HashMap<>();
-        for (ProjectApply applyEntity : applyEntities) {
-            long memberId = applyEntity.getUser().getId();
-            long projectId = applyEntity.getProject().getProjectId();
-            List<ApplyInfo> applyInfos = applyMap.computeIfAbsent(memberId, key ->
-                new ArrayList<>()
-            );
-            applyInfos.add(
-                ApplyInfo.builder()
-                    .userId(memberId)
-                    .projectId(projectId)
-                    .priority(applyEntity.getPriority())
-                    .position(applyEntity.getPosition())
-                    .build()
-            );
-        }
-
-        return applyMap;
-    }
-
-    private Map<Long, RecruitInfo> getRecruits(Position pos, List<Project> projects) {
-        List<ProjectRecruit> recruitEntities = recruitRepository.findAllBySemesterAndRoundAndPosition(
-            generateSemester(),
-            1, // 기존 관리자 배정은 1차 데이터만 사용한다.
-            pos
-        );
-        if (recruitEntities.isEmpty()) {
-            return Collections.emptyMap();
-        }
-
-        Map<Long, RecruitInfo> recruitMap = new HashMap<>();
-        for (ProjectRecruit recruitEntity : recruitEntities) {
-            long projectId = recruitEntity.getProjectId();
-            Set<Long> userIds = new LinkedHashSet<>();
-            for (ProjectRecruitWish wishEntity : recruitEntity.getWishList()) {
-                userIds.add(wishEntity.getApplicantId());
-            }
-
-            recruitMap.put(
-                projectId,
-                RecruitInfo.builder()
-                    .leaderId(recruitEntity.getLeaderId())
-                    .projectId(projectId)
-                    .position(recruitEntity.getPosition())
-                    .capacity(recruitEntity.getCapacity())
-                    .userIds(userIds)
-                    .build()
-            );
-        }
-
-        // 현재 pos에 관심이 없는 프로젝트는 cap(0), userIds(empty)로 세팅한다.
-        for (Project project : projects) {
-            long projectId = project.getProjectId();
-            if (!recruitMap.containsKey(projectId)) {
-                recruitMap.put(
-                    projectId,
-                    RecruitInfo.builder()
-                        .leaderId(project.getUser().getId())
-                        .projectId(projectId)
-                        .position(pos)
-                        .capacity(0)
-                        .userIds(new LinkedHashSet<>()) // 불변이 보장된다면 Collections.emptySet() 가능
-                        .build()
-                );
-            }
-        }
-
-        return recruitMap;
-    }
-
-    private TeamBuildingMeta findCurrentMeta() {
         String semester = generateSemester();
-        return teamBuildingMetaRepository
-            .findBySemester(semester)
-            .orElseThrow(() ->
-                new ConflictException("현재 학기의 팀빌딩이 초기화되지 않았습니다.")
-            );
-    }
-
-    private void validateTeamBuildingStatus(TeamBuildingMeta current) {
-        if (current.getStatus() != TeamBuildingStatus.CLOSED) {
-            throw new ConflictException("현재 팀빌딩 상태에서는 팀을 구성할 수 없습니다.");
+        TeamBuildingMeta meta = teamBuildingMetaRepository.findBySemesterForUpdate(semester)
+            .orElseThrow(() -> new ConflictException("현재 학기의 팀빌딩이 초기화되지 않았습니다."));
+        if (meta.getStatus() != TeamBuildingStatus.CLOSED || meta.getCompletedRound() >= meta.getRound()) {
+            throw new ConflictException("모집을 마친 미배정 차수에서만 팀을 구성할 수 있습니다.");
         }
-    }
-
-    //TODO: transactional 로 바꾸기
-    private void saveTeamBuildingResults(Map<Long, Map<Position, Set<Long>>> results) {
+        List<Project> projects = projectRepository.findProjectsBySemester(semester);
+        Map<Long, Long> leaders = new HashMap<>();
+        Set<Long> excluded = new HashSet<>();
+        projects.forEach(p -> { leaders.put(p.getProjectId(), p.getUser().getId()); excluded.add(p.getUser().getId()); });
+        teamRepository.findAllBySemester(semester).forEach(t -> excluded.add(t.getMemberId()));
+        var applies = applyRepository.findAllBySemesterAndRound(semester, meta.getRound());
+        var recruits = recruitRepository.findAllBySemesterAndRound(semester, meta.getRound()).stream()
+            .filter(r -> leaders.containsKey(r.getProjectId())).toList();
+        var allocation = teamBuilder.allocate(applies, recruits, excluded);
         List<Team> teams = new ArrayList<>();
-        for (Map.Entry<Long, Map<Position, Set<Long>>> projectEntry : results.entrySet()) {
-            Long projectId = projectEntry.getKey();
-            Long leaderId = projectRepository
-                .findById(projectId)
-                .map(project -> project.getUser().getId()) // leader id 찾기
-                .orElseThrow(() -> new ResourceNotFoundException("프로젝트를 찾을 수 없습니다."));
-
-            Map<Position, Set<Long>> byPosition = projectEntry.getValue();
-            for (Map.Entry<Position, Set<Long>> posEntry : byPosition.entrySet()) {
-                Position position = posEntry.getKey();
-                Set<Long> memberIds = posEntry.getValue();
-                for (Long memberId : memberIds) {
-                    teams.add(
-                        Team.builder()
-                            .projectId(projectId)
-                            .leaderId(leaderId)
-                            .position(position)
-                            .memberId(memberId)
-                            .semester(generateSemester())
-                            .build()
-                    );
-                }
-            }
-        }
-
+        allocation.forEach((slot, ids) -> ids.forEach(id -> teams.add(Team.builder()
+            .projectId(slot.projectId()).position(slot.position()).leaderId(leaders.get(slot.projectId()))
+            .memberId(id).semester(semester).round(meta.getRound()).build())));
         teamRepository.saveAll(teams);
+        meta.completeRound();
     }
 }

--- a/server/src/main/java/wap/web2/server/admin/service/AdminTeamBuildingService.java
+++ b/server/src/main/java/wap/web2/server/admin/service/AdminTeamBuildingService.java
@@ -122,8 +122,9 @@ public class AdminTeamBuildingService {
 
     // TODO: 내부 객체에 position 빼기
     private Map<Long, List<ApplyInfo>> getApplies(Position pos) {
-        List<ProjectApply> applyEntities = applyRepository.findAllBySemesterAndPosition(
+        List<ProjectApply> applyEntities = applyRepository.findAllBySemesterAndRoundAndPosition(
             generateSemester(),
+            1, // 기존 관리자 배정은 1차 데이터만 사용한다.
             pos
         );
         if (applyEntities.isEmpty()) {
@@ -151,8 +152,9 @@ public class AdminTeamBuildingService {
     }
 
     private Map<Long, RecruitInfo> getRecruits(Position pos, List<Project> projects) {
-        List<ProjectRecruit> recruitEntities = recruitRepository.findAllBySemesterAndPosition(
+        List<ProjectRecruit> recruitEntities = recruitRepository.findAllBySemesterAndRoundAndPosition(
             generateSemester(),
+            1, // 기존 관리자 배정은 1차 데이터만 사용한다.
             pos
         );
         if (recruitEntities.isEmpty()) {

--- a/server/src/main/java/wap/web2/server/admin/service/ThirdRoundTeamBuildingService.java
+++ b/server/src/main/java/wap/web2/server/admin/service/ThirdRoundTeamBuildingService.java
@@ -1,0 +1,113 @@
+package wap.web2.server.admin.service;
+
+import static wap.web2.server.util.SemesterGenerator.generateSemester;
+import java.util.*;
+import java.util.random.RandomGenerator;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import wap.web2.server.admin.entity.*;
+import wap.web2.server.admin.repository.TeamBuildingMetaRepository;
+import wap.web2.server.exception.*;
+import wap.web2.server.project.entity.Project;
+import wap.web2.server.project.repository.ProjectRepository;
+import wap.web2.server.teambuild.entity.*;
+import wap.web2.server.teambuild.repository.*;
+import wap.web2.server.teambuild.service.*;
+import wap.web2.server.teambuild.service.PositionTeamBuilder.Slot;
+
+/** Server-side administration; no new frontend endpoints are exposed. */
+@Service
+@RequiredArgsConstructor
+public class ThirdRoundTeamBuildingService {
+    private final TeamBuildingMetaRepository metaRepository;
+    private final FieldClusterMemberRepository clusterRepository;
+    private final ProjectApplyRepository applyRepository;
+    private final ProjectRecruitRepository recruitRepository;
+    private final TeamRepository teamRepository;
+    private final ProjectRepository projectRepository;
+    private final FieldClusterer clusterer;
+    private final RandomFieldTeamBuilder builder;
+
+    @Transactional(readOnly = true)
+    public List<FieldClusterMember> getClusters() {
+        return clusterRepository.findAllBySemesterOrderByUserId(generateSemester());
+    }
+
+    @Transactional
+    public List<FieldClusterMember> rebuildClusters() {
+        lockReadyMeta();
+        String semester = generateSemester();
+        Map<Long, Position> clusters = currentCandidates();
+        clusterRepository.deleteBySemester(semester);
+        return clusterRepository.saveAll(clusters.entrySet().stream()
+            .map(e -> new FieldClusterMember(semester, e.getKey(), e.getValue())).toList());
+    }
+
+    @Transactional
+    public void updateClusters(Map<Long, Position> changes) {
+        lockReadyMeta();
+        if (changes == null) throw new BadRequestException("수정할 클러스터가 필요합니다.");
+        Map<Long, FieldClusterMember> members = getClusters().stream()
+            .collect(Collectors.toMap(FieldClusterMember::getUserId, m -> m));
+        Set<Long> eligible = currentCandidates().keySet();
+        changes.forEach((id, position) -> {
+            if (!eligible.contains(id) || !members.containsKey(id) || position == null) {
+                throw new BadRequestException("미배정 클러스터 멤버와 유효한 분야를 지정해야 합니다.");
+            }
+        });
+        changes.forEach((id, position) -> members.get(id).changePosition(position));
+    }
+
+    @Transactional
+    public void allocate() {
+        TeamBuildingMeta meta = lockReadyMeta();
+        String semester = generateSemester();
+        Map<Long, Position> clusters = getClusters().stream()
+            .collect(Collectors.toMap(FieldClusterMember::getUserId, FieldClusterMember::getPosition));
+        if (!clusters.keySet().equals(currentCandidates().keySet())) {
+            throw new ConflictException("현재 미배정 인원으로 클러스터를 생성한 후 배정해야 합니다.");
+        }
+        Map<Long, Long> leaders = projectRepository.findProjectsBySemester(semester).stream()
+            .collect(Collectors.toMap(Project::getProjectId, p -> p.getUser().getId()));
+        Map<Slot, ProjectRecruit> latest = new HashMap<>();
+        for (int round : List.of(1, 2)) {
+            for (ProjectRecruit recruit : recruitRepository.findAllBySemesterAndRound(semester, round)) {
+                if (leaders.containsKey(recruit.getProjectId()))
+                    latest.put(new Slot(recruit.getProjectId(), recruit.getPosition()), recruit);
+            }
+        }
+        List<Team> existing = teamRepository.findAllBySemester(semester);
+        Map<Slot, Integer> vacancies = new HashMap<>();
+        latest.forEach((slot, recruit) -> {
+            long filled = existing.stream().filter(t -> t.getProjectId().equals(slot.projectId())
+                && t.getPosition() == slot.position() && t.getRound() >= recruit.getRound()).count();
+            vacancies.put(slot, Math.max(0, recruit.getCapacity() - (int) filled));
+        });
+        var allocation = builder.allocate(clusters, vacancies, RandomGenerator.getDefault());
+        List<Team> teams = new ArrayList<>();
+        allocation.forEach((slot, ids) -> ids.forEach(id -> teams.add(Team.builder()
+            .projectId(slot.projectId()).position(slot.position()).memberId(id)
+            .leaderId(leaders.get(slot.projectId())).semester(semester).round(3).build())));
+        teamRepository.saveAll(teams);
+        meta.completeThirdRound();
+    }
+
+    private Map<Long, Position> currentCandidates() {
+        String semester = generateSemester();
+        Set<Long> excluded = new HashSet<>();
+        teamRepository.findAllBySemester(semester).forEach(t -> excluded.add(t.getMemberId()));
+        projectRepository.findProjectsBySemester(semester).forEach(p -> excluded.add(p.getUser().getId()));
+        return clusterer.cluster(applyRepository.findAllBySemester(semester), excluded);
+    }
+
+    private TeamBuildingMeta lockReadyMeta() {
+        TeamBuildingMeta meta = metaRepository.findBySemesterForUpdate(generateSemester())
+            .orElseThrow(() -> new ConflictException("팀빌딩이 초기화되지 않았습니다."));
+        if (meta.getStatus() != TeamBuildingStatus.CLOSED || meta.getCompletedRound() != 2) {
+            throw new ConflictException("2차 배정 완료 후에만 3차 팀빌딩을 진행할 수 있습니다.");
+        }
+        return meta;
+    }
+}

--- a/server/src/main/java/wap/web2/server/member/repository/UserRepository.java
+++ b/server/src/main/java/wap/web2/server/member/repository/UserRepository.java
@@ -1,5 +1,7 @@
 package wap.web2.server.member.repository;
 
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,6 +14,10 @@ import wap.web2.server.member.entity.User;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT u FROM User u WHERE u.id = :id")
+    Optional<User> findByIdForUpdate(@Param("id") Long id);
+
     Optional<User> findByEmail(String email);
 
     Boolean existsByEmail(String email);

--- a/server/src/main/java/wap/web2/server/teambuild/controller/TeamBuildingControllerV3.java
+++ b/server/src/main/java/wap/web2/server/teambuild/controller/TeamBuildingControllerV3.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import wap.web2.server.global.security.CurrentUser;
 import wap.web2.server.global.security.UserPrincipal;
@@ -59,27 +60,30 @@ public class TeamBuildingControllerV3 {
     @PostMapping("/apply/submit")
     public ResponseEntity<String> apply(
         @CurrentUser UserPrincipal userPrincipal,
+        @RequestParam(name = "round", defaultValue = "1") int round,
         @Valid @RequestBody ProjectAppliesRequest request
     ) {
-        applyService.apply(userPrincipal, request);
+        applyService.apply(userPrincipal, request, round);
         return ResponseEntity.ok("지원이 완료되었습니다.");
     }
 
     @PostMapping("/recruit/submit")
     public ResponseEntity<String> setPreference(
         @CurrentUser UserPrincipal userPrincipal,
+        @RequestParam(name = "round", defaultValue = "1") int round,
         @Valid @RequestBody RecruitmentDto request
     ) {
-        applyService.setPreference(userPrincipal, request);
+        applyService.setPreference(userPrincipal, request, round);
         return ResponseEntity.ok("모집 정보가 등록되었습니다.");
     }
 
     @GetMapping("/{projectId}/applies")
     public ResponseEntity<ProjectAppliesResponse> getRecruitPageData(
         @CurrentUser UserPrincipal userPrincipal,
+        @RequestParam(name = "round", defaultValue = "1") int round,
         @PathVariable("projectId") Long projectId
     ) {
-        ProjectAppliesResponse response = applyService.getRecruitPageData(userPrincipal, projectId);
+        ProjectAppliesResponse response = applyService.getRecruitPageData(userPrincipal, projectId, round);
         return ResponseEntity.ok(response);
     }
 

--- a/server/src/main/java/wap/web2/server/teambuild/dto/request/ProjectAppliesRequest.java
+++ b/server/src/main/java/wap/web2/server/teambuild/dto/request/ProjectAppliesRequest.java
@@ -39,6 +39,16 @@ public class ProjectAppliesRequest {
 
         private String career;
 
+        private String experience;
+
+        public ApplyRequest(Long projectId, String position, String comment, String career) {
+            this(projectId, position, comment, career, null);
+        }
+
+        public String getExperience() {
+            return experience != null ? experience : career;
+        }
+
         public ApplyRequest(Long projectId, String position, String comment) {
             this(projectId, position, comment, null);
         }

--- a/server/src/main/java/wap/web2/server/teambuild/dto/response/ProjectAppliesResponse.java
+++ b/server/src/main/java/wap/web2/server/teambuild/dto/response/ProjectAppliesResponse.java
@@ -22,6 +22,10 @@ public class ProjectAppliesResponse {
         private String position;
         private String comment;
         private String career;
+
+        public String getExperience() {
+            return career;
+        }
         private String applicantName;
         private Long applicantId;
     }

--- a/server/src/main/java/wap/web2/server/teambuild/entity/FieldClusterMember.java
+++ b/server/src/main/java/wap/web2/server/teambuild/entity/FieldClusterMember.java
@@ -1,0 +1,26 @@
+package wap.web2.server.teambuild.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"semester", "user_id"}))
+public class FieldClusterMember {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false, length = 7)
+    private String semester;
+    @Column(nullable = false)
+    private Long userId;
+    @Enumerated(EnumType.STRING) @Column(nullable = false, length = 32)
+    private Position position;
+
+    public FieldClusterMember(String semester, Long userId, Position position) {
+        this.semester = semester; this.userId = userId; this.position = position;
+    }
+    public void changePosition(Position position) {
+        this.position = position;
+    }
+}

--- a/server/src/main/java/wap/web2/server/teambuild/entity/ProjectApply.java
+++ b/server/src/main/java/wap/web2/server/teambuild/entity/ProjectApply.java
@@ -44,6 +44,10 @@ public class ProjectApply {
     @Column(columnDefinition = "TEXT")
     private String career;
 
+    @Builder.Default
+    @Column(nullable = false)
+    private int round = 1;
+
     @Column(nullable = false, length = 7)
     private String semester; // "year-semester"
 

--- a/server/src/main/java/wap/web2/server/teambuild/entity/ProjectRecruit.java
+++ b/server/src/main/java/wap/web2/server/teambuild/entity/ProjectRecruit.java
@@ -47,6 +47,10 @@ public class ProjectRecruit {
     @Column(nullable = false)
     private Integer capacity;
 
+    @Builder.Default
+    @Column(nullable = false)
+    private int round = 1;
+
     @Column(nullable = false, length = 7)
     private String semester; // "year-semester"
 

--- a/server/src/main/java/wap/web2/server/teambuild/entity/Team.java
+++ b/server/src/main/java/wap/web2/server/teambuild/entity/Team.java
@@ -36,6 +36,10 @@ public class Team {
     @Enumerated(EnumType.STRING)
     private Position position;
 
+    @Builder.Default
+    @Column(nullable = false)
+    private int round = 1;
+
     @Column(nullable = false, length = 7)
     private String semester;
 }

--- a/server/src/main/java/wap/web2/server/teambuild/repository/FieldClusterMemberRepository.java
+++ b/server/src/main/java/wap/web2/server/teambuild/repository/FieldClusterMemberRepository.java
@@ -1,0 +1,13 @@
+package wap.web2.server.teambuild.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+import wap.web2.server.teambuild.entity.FieldClusterMember;
+
+public interface FieldClusterMemberRepository extends JpaRepository<FieldClusterMember, Long> {
+    List<FieldClusterMember> findAllBySemesterOrderByUserId(String semester);
+    @Modifying
+    @Query("DELETE FROM FieldClusterMember c WHERE c.semester = :semester")
+    void deleteBySemester(@Param("semester") String semester);
+}

--- a/server/src/main/java/wap/web2/server/teambuild/repository/ProjectApplyRepository.java
+++ b/server/src/main/java/wap/web2/server/teambuild/repository/ProjectApplyRepository.java
@@ -18,6 +18,8 @@ public interface ProjectApplyRepository extends JpaRepository<ProjectApply, Long
 
     List<ProjectApply> findAllByProjectAndSemesterAndRound(Project project, String semester, int round);
 
+    List<ProjectApply> findAllBySemesterAndRound(String semester, int round);
+
     List<ProjectApply> findAllBySemesterAndRoundAndPosition(String semester, int round, Position position);
 
     List<ProjectApply> findByProject_ProjectIdAndSemesterAndUser_IdInOrderByPriorityAsc(

--- a/server/src/main/java/wap/web2/server/teambuild/repository/ProjectApplyRepository.java
+++ b/server/src/main/java/wap/web2/server/teambuild/repository/ProjectApplyRepository.java
@@ -14,6 +14,8 @@ import wap.web2.server.teambuild.entity.ProjectApply;
 public interface ProjectApplyRepository extends JpaRepository<ProjectApply, Long> {
     List<ProjectApply> findAllByProject(Project project);
 
+    List<ProjectApply> findAllByUserIdAndSemesterAndRound(Long userId, String semester, int round);
+
     List<ProjectApply> findAllByProjectAndSemesterAndRound(Project project, String semester, int round);
 
     List<ProjectApply> findAllBySemesterAndRoundAndPosition(String semester, int round, Position position);

--- a/server/src/main/java/wap/web2/server/teambuild/repository/ProjectApplyRepository.java
+++ b/server/src/main/java/wap/web2/server/teambuild/repository/ProjectApplyRepository.java
@@ -14,6 +14,8 @@ import wap.web2.server.teambuild.entity.ProjectApply;
 public interface ProjectApplyRepository extends JpaRepository<ProjectApply, Long> {
     List<ProjectApply> findAllByProject(Project project);
 
+    List<ProjectApply> findAllByProjectAndSemesterAndRound(Project project, String semester, int round);
+
     List<ProjectApply> findAllBySemesterAndPosition(String semester, Position position);
 
     List<ProjectApply> findByProject_ProjectIdAndSemesterAndUser_IdInOrderByPriorityAsc(

--- a/server/src/main/java/wap/web2/server/teambuild/repository/ProjectApplyRepository.java
+++ b/server/src/main/java/wap/web2/server/teambuild/repository/ProjectApplyRepository.java
@@ -16,7 +16,7 @@ public interface ProjectApplyRepository extends JpaRepository<ProjectApply, Long
 
     List<ProjectApply> findAllByProjectAndSemesterAndRound(Project project, String semester, int round);
 
-    List<ProjectApply> findAllBySemesterAndPosition(String semester, Position position);
+    List<ProjectApply> findAllBySemesterAndRoundAndPosition(String semester, int round, Position position);
 
     List<ProjectApply> findByProject_ProjectIdAndSemesterAndUser_IdInOrderByPriorityAsc(
         Long projectId,

--- a/server/src/main/java/wap/web2/server/teambuild/repository/ProjectRecruitRepository.java
+++ b/server/src/main/java/wap/web2/server/teambuild/repository/ProjectRecruitRepository.java
@@ -12,6 +12,8 @@ import wap.web2.server.teambuild.entity.ProjectRecruit;
 public interface ProjectRecruitRepository extends JpaRepository<ProjectRecruit, Long> {
     Boolean existsByProjectIdAndSemester(Long projectId, String semester);
 
+    boolean existsByProjectIdAndSemesterAndRound(Long projectId, String semester, int round);
+
     List<ProjectRecruit> findAllBySemesterAndPosition(String semester, Position position);
 
     Page<ProjectRecruit> findAllBySemester(String semester, PageRequest of);

--- a/server/src/main/java/wap/web2/server/teambuild/repository/ProjectRecruitRepository.java
+++ b/server/src/main/java/wap/web2/server/teambuild/repository/ProjectRecruitRepository.java
@@ -14,6 +14,8 @@ public interface ProjectRecruitRepository extends JpaRepository<ProjectRecruit, 
 
     boolean existsByProjectIdAndSemesterAndRound(Long projectId, String semester, int round);
 
+    List<ProjectRecruit> findAllBySemesterAndRound(String semester, int round);
+
     List<ProjectRecruit> findAllBySemesterAndRoundAndPosition(String semester, int round, Position position);
 
     Page<ProjectRecruit> findAllBySemester(String semester, PageRequest of);

--- a/server/src/main/java/wap/web2/server/teambuild/repository/ProjectRecruitRepository.java
+++ b/server/src/main/java/wap/web2/server/teambuild/repository/ProjectRecruitRepository.java
@@ -14,7 +14,7 @@ public interface ProjectRecruitRepository extends JpaRepository<ProjectRecruit, 
 
     boolean existsByProjectIdAndSemesterAndRound(Long projectId, String semester, int round);
 
-    List<ProjectRecruit> findAllBySemesterAndPosition(String semester, Position position);
+    List<ProjectRecruit> findAllBySemesterAndRoundAndPosition(String semester, int round, Position position);
 
     Page<ProjectRecruit> findAllBySemester(String semester, PageRequest of);
 }

--- a/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
+++ b/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
@@ -56,16 +56,16 @@ public class ApplyService {
     @Transactional
     public void apply(UserPrincipal userPrincipal, ProjectAppliesRequest request, int round) {
         validateRound(round);
-        if (!isTeamApplyOpen(round)) {
-            throw new ConflictException("현재 팀빌딩 상태에서는 지원할 수 없습니다.");
-        }
+        String semester = generateSemester();
+        validateAndLockSubmission(semester, round, TeamBuildingStatus.APPLY,
+            "현재 팀빌딩 상태에서는 지원할 수 없습니다.");
 
         // Serialize submissions by the same applicant so concurrent requests cannot exceed five.
         User user = userRepository.findByIdForUpdate(userPrincipal.getId())
             .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다."));
         List<ApplyRequest> applies = request.getApplies();
         List<ProjectApply> existing = applyRepository.findAllByUserIdAndSemesterAndRound(
-            user.getId(), generateSemester(), round);
+            user.getId(), semester, round);
         if (applies == null || applies.isEmpty() || existing.size() + applies.size() > 5) {
             throw new BadRequestException("차수별 지원은 1개 이상 5개 이하만 가능합니다.");
         }
@@ -92,6 +92,7 @@ public class ApplyService {
                     ProjectApply.builder()
                             .priority(priority++)
                             .round(round)
+                            .semester(semester)
                             .position(parsePosition(applyRequest.getPosition()))
                             .comment(applyRequest.getComment())
                             .career(applyRequest.getExperience())
@@ -164,9 +165,9 @@ public class ApplyService {
     @Transactional
     public void setPreference(UserPrincipal userPrincipal, RecruitmentDto request, int round) {
         validateRound(round);
-        if (!isTeamRecruitOpen(round)) {
-            throw new ConflictException("현재 팀빌딩 상태에서는 모집을 제출할 수 없습니다.");
-        }
+        String semester = generateSemester();
+        validateAndLockSubmission(semester, round, TeamBuildingStatus.RECRUIT,
+            "현재 팀빌딩 상태에서는 모집을 제출할 수 없습니다.");
 
         User user = findUser(userPrincipal.getId());
         Project project = findProject(request.getProjectId());
@@ -179,11 +180,12 @@ public class ApplyService {
 
         List<RecruitmentInfo> roasters = request.getRoasters();
         RecruitmentPolicy.validate(roasters,
-            applyRepository.findAllByProjectAndSemesterAndRound(project, generateSemester(), round), round);
+            applyRepository.findAllByProjectAndSemesterAndRound(project, semester, round), round);
         for (RecruitmentInfo roaster : roasters) {
             ProjectRecruit recruit = recruitRepository.save(
                 ProjectRecruit.builder()
                     .round(round)
+                    .semester(semester)
                     .leaderId(user.getId())
                     .projectId(project.getProjectId())
                     .position(parsePosition(roaster.getPosition()))
@@ -222,26 +224,17 @@ public class ApplyService {
         }
     }
 
-    private boolean isTeamApplyOpen(int round) {
-        String semester = generateSemester();
-        TeamBuildingMeta teamBuildingMeta = teamBuildingMetaRepository
-            .findBySemester(semester)
+    private void validateAndLockSubmission(String semester, int round,
+                                           TeamBuildingStatus expectedStatus, String message) {
+        // Lock meta before user/data access, matching admin operations. The caller's
+        // transaction keeps this lock through commit so closing cannot overtake a submission.
+        TeamBuildingMeta meta = teamBuildingMetaRepository.findBySemesterForUpdate(semester)
             .orElseThrow(() ->
                 new ConflictException("현재 학기의 팀빌딩이 초기화되지 않았습니다.")
             );
-
-        return teamBuildingMeta.getRound() == round && teamBuildingMeta.getStatus() == TeamBuildingStatus.APPLY;
-    }
-
-    private boolean isTeamRecruitOpen(int round) {
-        String semester = generateSemester();
-        TeamBuildingMeta teamBuildingMeta = teamBuildingMetaRepository
-            .findBySemester(semester)
-            .orElseThrow(() ->
-                new ConflictException("현재 학기의 팀빌딩이 초기화되지 않았습니다.")
-            );
-
-        return teamBuildingMeta.getRound() == round && teamBuildingMeta.getStatus() == TeamBuildingStatus.RECRUIT;
+        if (meta.getRound() != round || meta.getStatus() != expectedStatus) {
+            throw new ConflictException(message);
+        }
     }
 
     private User findUser(Long userId) {

--- a/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
+++ b/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
@@ -56,7 +56,7 @@ public class ApplyService {
     @Transactional
     public void apply(UserPrincipal userPrincipal, ProjectAppliesRequest request, int round) {
         validateRound(round);
-        if (!isTeamApplyOpen()) {
+        if (!isTeamApplyOpen(round)) {
             throw new ConflictException("현재 팀빌딩 상태에서는 지원할 수 없습니다.");
         }
 
@@ -164,7 +164,7 @@ public class ApplyService {
     @Transactional
     public void setPreference(UserPrincipal userPrincipal, RecruitmentDto request, int round) {
         validateRound(round);
-        if (!isTeamRecruitOpen()) {
+        if (!isTeamRecruitOpen(round)) {
             throw new ConflictException("현재 팀빌딩 상태에서는 모집을 제출할 수 없습니다.");
         }
 
@@ -211,7 +211,9 @@ public class ApplyService {
     @Transactional(readOnly = true)
     public boolean hasAppliedThisSemester(Long userId) {
         findUser(userId);
-        return applyRepository.existsByUserIdAndSemester(userId, generateSemester());
+        int round = teamBuildingMetaRepository.findBySemester(generateSemester())
+            .map(TeamBuildingMeta::getRound).orElse(1);
+        return !applyRepository.findAllByUserIdAndSemesterAndRound(userId, generateSemester(), round).isEmpty();
     }
 
     private void validateRound(int round) {
@@ -220,7 +222,7 @@ public class ApplyService {
         }
     }
 
-    private boolean isTeamApplyOpen() {
+    private boolean isTeamApplyOpen(int round) {
         String semester = generateSemester();
         TeamBuildingMeta teamBuildingMeta = teamBuildingMetaRepository
             .findBySemester(semester)
@@ -228,10 +230,10 @@ public class ApplyService {
                 new ConflictException("현재 학기의 팀빌딩이 초기화되지 않았습니다.")
             );
 
-        return teamBuildingMeta.getStatus() == TeamBuildingStatus.APPLY;
+        return teamBuildingMeta.getRound() == round && teamBuildingMeta.getStatus() == TeamBuildingStatus.APPLY;
     }
 
-    private boolean isTeamRecruitOpen() {
+    private boolean isTeamRecruitOpen(int round) {
         String semester = generateSemester();
         TeamBuildingMeta teamBuildingMeta = teamBuildingMetaRepository
             .findBySemester(semester)
@@ -239,7 +241,7 @@ public class ApplyService {
                 new ConflictException("현재 학기의 팀빌딩이 초기화되지 않았습니다.")
             );
 
-        return teamBuildingMeta.getStatus() == TeamBuildingStatus.RECRUIT;
+        return teamBuildingMeta.getRound() == round && teamBuildingMeta.getStatus() == TeamBuildingStatus.RECRUIT;
     }
 
     private User findUser(Long userId) {

--- a/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
+++ b/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
@@ -178,6 +178,8 @@ public class ApplyService {
         log.info("setPreference-user:{},project:{}", user.getId(), project.getProjectId());
 
         List<RecruitmentInfo> roasters = request.getRoasters();
+        RecruitmentPolicy.validate(roasters,
+            applyRepository.findAllByProjectAndSemesterAndRound(project, generateSemester(), round), round);
         for (RecruitmentInfo roaster : roasters) {
             ProjectRecruit recruit = recruitRepository.save(
                 ProjectRecruit.builder()

--- a/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
+++ b/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
@@ -4,6 +4,9 @@ import static wap.web2.server.util.SemesterGenerator.generateSemester;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -57,9 +60,24 @@ public class ApplyService {
             throw new ConflictException("현재 팀빌딩 상태에서는 지원할 수 없습니다.");
         }
 
-        User user = findUser(userPrincipal.getId());
+        // Serialize submissions by the same applicant so concurrent requests cannot exceed five.
+        User user = userRepository.findByIdForUpdate(userPrincipal.getId())
+            .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다."));
         List<ApplyRequest> applies = request.getApplies();
-        int priority = 1;
+        List<ProjectApply> existing = applyRepository.findAllByUserIdAndSemesterAndRound(
+            user.getId(), generateSemester(), round);
+        if (applies == null || applies.isEmpty() || existing.size() + applies.size() > 5) {
+            throw new BadRequestException("차수별 지원은 1개 이상 5개 이하만 가능합니다.");
+        }
+        Set<ApplicationChoice> choices = new HashSet<>();
+        existing.forEach(a -> choices.add(new ApplicationChoice(a.getProject().getProjectId(), a.getPosition())));
+        for (ApplyRequest entry : applies) {
+            if (entry == null || entry.getProjectId() == null ||
+                !choices.add(new ApplicationChoice(entry.getProjectId(), parsePosition(entry.getPosition())))) {
+                throw new BadRequestException("동일한 프로젝트와 직무에 중복 지원할 수 없습니다.");
+            }
+        }
+        int priority = existing.stream().mapToInt(ProjectApply::getPriority).max().orElse(0) + 1;
 
         for (ApplyRequest applyRequest : applies) {
             Project project = findProject(applyRequest.getProjectId());
@@ -76,7 +94,7 @@ public class ApplyService {
                             .round(round)
                             .position(parsePosition(applyRequest.getPosition()))
                             .comment(applyRequest.getComment())
-                            .career(applyRequest.getCareer())
+                            .career(applyRequest.getExperience())
                             .user(user)
                             .project(project)
                             .build()
@@ -234,10 +252,12 @@ public class ApplyService {
             .orElseThrow(() -> new ResourceNotFoundException("프로젝트를 찾을 수 없습니다."));
     }
 
+    private record ApplicationChoice(Long projectId, Position position) {}
+
     private Position parsePosition(String position) {
         try {
-            return Position.valueOf(position);
-        } catch (IllegalArgumentException e) {
+            return Position.valueOf(position.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException | NullPointerException e) {
             throw new BadRequestException("유효하지 않은 포지션입니다.");
         }
     }

--- a/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
+++ b/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
@@ -47,6 +47,12 @@ public class ApplyService {
 
     @Transactional
     public void apply(UserPrincipal userPrincipal, ProjectAppliesRequest request) {
+        apply(userPrincipal, request, 1);
+    }
+
+    @Transactional
+    public void apply(UserPrincipal userPrincipal, ProjectAppliesRequest request, int round) {
+        validateRound(round);
         if (!isTeamApplyOpen()) {
             throw new ConflictException("현재 팀빌딩 상태에서는 지원할 수 없습니다.");
         }
@@ -67,6 +73,7 @@ public class ApplyService {
             applyRepository.save(
                     ProjectApply.builder()
                             .priority(priority++)
+                            .round(round)
                             .position(parsePosition(applyRequest.getPosition()))
                             .comment(applyRequest.getComment())
                             .career(applyRequest.getCareer())
@@ -79,6 +86,12 @@ public class ApplyService {
 
     @Transactional(readOnly = true)
     public boolean hasRecruited(UserPrincipal userPrincipal, Long projectId) {
+        return hasRecruited(userPrincipal, projectId, 1);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean hasRecruited(UserPrincipal userPrincipal, Long projectId, int round) {
+        validateRound(round);
         User user = findUser(userPrincipal.getId());
         Project project = findProject(projectId);
 
@@ -86,11 +99,17 @@ public class ApplyService {
             throw new ForbiddenException("프로젝트 열람 권한이 없습니다.");
         }
 
-        return recruitRepository.existsByProjectIdAndSemester(projectId, generateSemester());
+        return recruitRepository.existsByProjectIdAndSemesterAndRound(projectId, generateSemester(), round);
     }
 
     @Transactional(readOnly = true)
     public ProjectAppliesResponse getApplies(UserPrincipal userPrincipal, Long projectId) {
+        return getApplies(userPrincipal, projectId, 1);
+    }
+
+    @Transactional(readOnly = true)
+    public ProjectAppliesResponse getApplies(UserPrincipal userPrincipal, Long projectId, int round) {
+        validateRound(round);
         User user = findUser(userPrincipal.getId());
         Project project = findProject(projectId);
 
@@ -98,7 +117,7 @@ public class ApplyService {
             throw new ForbiddenException("프로젝트 열람 권한이 없습니다.");
         }
 
-        List<ProjectApply> applies = applyRepository.findAllByProject(project);
+        List<ProjectApply> applies = applyRepository.findAllByProjectAndSemesterAndRound(project, generateSemester(), round);
         log.info("getApplies-user:{}", user.getName());
 
         return ProjectAppliesResponse.fromEntities(applies);
@@ -106,15 +125,27 @@ public class ApplyService {
 
     @Transactional(readOnly = true)
     public ProjectAppliesResponse getRecruitPageData(UserPrincipal userPrincipal, Long projectId) {
-        if (hasRecruited(userPrincipal, projectId)) {
+        return getRecruitPageData(userPrincipal, projectId, 1);
+    }
+
+    @Transactional(readOnly = true)
+    public ProjectAppliesResponse getRecruitPageData(UserPrincipal userPrincipal, Long projectId, int round) {
+        validateRound(round);
+        if (hasRecruited(userPrincipal, projectId, round)) {
             throw new ConflictException("이미 제출된 모집이 존재합니다.");
         }
 
-        return getApplies(userPrincipal, projectId);
+        return getApplies(userPrincipal, projectId, round);
     }
 
     @Transactional
     public void setPreference(UserPrincipal userPrincipal, RecruitmentDto request) {
+        setPreference(userPrincipal, request, 1);
+    }
+
+    @Transactional
+    public void setPreference(UserPrincipal userPrincipal, RecruitmentDto request, int round) {
+        validateRound(round);
         if (!isTeamRecruitOpen()) {
             throw new ConflictException("현재 팀빌딩 상태에서는 모집을 제출할 수 없습니다.");
         }
@@ -132,6 +163,7 @@ public class ApplyService {
         for (RecruitmentInfo roaster : roasters) {
             ProjectRecruit recruit = recruitRepository.save(
                 ProjectRecruit.builder()
+                    .round(round)
                     .leaderId(user.getId())
                     .projectId(project.getProjectId())
                     .position(parsePosition(roaster.getPosition()))
@@ -160,6 +192,12 @@ public class ApplyService {
     public boolean hasAppliedThisSemester(Long userId) {
         findUser(userId);
         return applyRepository.existsByUserIdAndSemester(userId, generateSemester());
+    }
+
+    private void validateRound(int round) {
+        if (round != 1 && round != 2) {
+            throw new BadRequestException("지원 및 모집 차수는 1 또는 2여야 합니다.");
+        }
     }
 
     private boolean isTeamApplyOpen() {

--- a/server/src/main/java/wap/web2/server/teambuild/service/FieldClusterer.java
+++ b/server/src/main/java/wap/web2/server/teambuild/service/FieldClusterer.java
@@ -1,0 +1,24 @@
+package wap.web2.server.teambuild.service;
+
+import java.util.*;
+import org.springframework.stereotype.Component;
+import wap.web2.server.teambuild.entity.*;
+
+/** Latest-round first choice determines each unassigned applicant's initial field. */
+@Component
+public class FieldClusterer {
+    public Map<Long, Position> cluster(List<ProjectApply> applies, Set<Long> excluded) {
+        Comparator<ProjectApply> preference = Comparator.comparingInt(ProjectApply::getRound).reversed()
+            .thenComparing(ProjectApply::getPriority).thenComparing(ProjectApply::getPosition)
+            .thenComparing(a -> a.getProject().getProjectId());
+        Map<Long, ProjectApply> choices = new TreeMap<>();
+        for (ProjectApply apply : applies) {
+            Long id = apply.getUser().getId();
+            if (!excluded.contains(id)) choices.merge(id, apply,
+                (left, right) -> preference.compare(left, right) <= 0 ? left : right);
+        }
+        Map<Long, Position> clusters = new LinkedHashMap<>();
+        choices.forEach((id, apply) -> clusters.put(id, apply.getPosition()));
+        return clusters;
+    }
+}

--- a/server/src/main/java/wap/web2/server/teambuild/service/PositionTeamBuilder.java
+++ b/server/src/main/java/wap/web2/server/teambuild/service/PositionTeamBuilder.java
@@ -1,0 +1,59 @@
+package wap.web2.server.teambuild.service;
+
+import java.util.*;
+import org.springframework.stereotype.Component;
+import wap.web2.server.teambuild.entity.*;
+
+/** Leader-proposing allocation over (project, position) slots with one assignment per person. */
+@Component
+public class PositionTeamBuilder {
+    public record Slot(Long projectId, Position position) {}
+
+    public Map<Slot, Set<Long>> allocate(List<ProjectApply> applies, List<ProjectRecruit> recruits,
+                                        Set<Long> excluded) {
+        Comparator<Slot> order = Comparator.comparing(Slot::projectId).thenComparing(Slot::position);
+        Map<Slot, Map<Long, Integer>> ranks = new HashMap<>();
+        for (ProjectApply apply : applies) {
+            ranks.computeIfAbsent(new Slot(apply.getProject().getProjectId(), apply.getPosition()),
+                key -> new HashMap<>()).merge(apply.getUser().getId(), apply.getPriority(), Math::min);
+        }
+        Map<Slot, Integer> capacities = new TreeMap<>(order);
+        Map<Slot, List<Long>> candidates = new HashMap<>();
+        for (ProjectRecruit recruit : recruits) {
+            Slot slot = new Slot(recruit.getProjectId(), recruit.getPosition());
+            capacities.put(slot, Math.max(0, recruit.getCapacity()));
+            candidates.put(slot, recruit.getWishList().stream()
+                .sorted(Comparator.comparing(ProjectRecruitWish::getPriority)
+                    .thenComparing(ProjectRecruitWish::getApplicantId))
+                .map(ProjectRecruitWish::getApplicantId).distinct()
+                .filter(id -> !excluded.contains(id) && ranks.getOrDefault(slot, Map.of()).containsKey(id))
+                .toList());
+        }
+        Map<Slot, Set<Long>> result = new LinkedHashMap<>();
+        capacities.keySet().forEach(slot -> result.put(slot, new LinkedHashSet<>()));
+        Map<Long, Slot> assigned = new HashMap<>();
+        Map<Slot, Integer> cursors = new HashMap<>();
+        Deque<Slot> pending = new ArrayDeque<>(capacities.keySet());
+        while (!pending.isEmpty()) {
+            Slot slot = pending.removeFirst();
+            List<Long> wishes = candidates.get(slot);
+            int cursor = cursors.getOrDefault(slot, 0);
+            while (result.get(slot).size() < capacities.get(slot) && cursor < wishes.size()) {
+                Long id = wishes.get(cursor++);
+                Slot previous = assigned.get(id);
+                boolean preferred = previous == null || ranks.get(slot).get(id) < ranks.get(previous).get(id)
+                    || (ranks.get(slot).get(id).equals(ranks.get(previous).get(id)) && order.compare(slot, previous) < 0);
+                if (preferred) {
+                    if (previous != null) {
+                        result.get(previous).remove(id);
+                        pending.addLast(previous);
+                    }
+                    result.get(slot).add(id);
+                    assigned.put(id, slot);
+                }
+            }
+            cursors.put(slot, cursor);
+        }
+        return result;
+    }
+}

--- a/server/src/main/java/wap/web2/server/teambuild/service/RandomFieldTeamBuilder.java
+++ b/server/src/main/java/wap/web2/server/teambuild/service/RandomFieldTeamBuilder.java
@@ -1,0 +1,46 @@
+package wap.web2.server.teambuild.service;
+
+import java.util.*;
+import java.util.random.RandomGenerator;
+import org.springframework.stereotype.Component;
+import wap.web2.server.exception.BadRequestException;
+import wap.web2.server.teambuild.entity.Position;
+import wap.web2.server.teambuild.service.PositionTeamBuilder.Slot;
+
+@Component
+public class RandomFieldTeamBuilder {
+    public Map<Slot, Set<Long>> allocate(Map<Long, Position> clusters, Map<Slot, Integer> vacancies,
+                                        RandomGenerator random) {
+        Map<Slot, Set<Long>> result = new LinkedHashMap<>();
+        vacancies.entrySet().stream().sorted(Map.Entry.comparingByKey(
+            Comparator.comparing(Slot::projectId).thenComparing(Slot::position)))
+            .forEach(entry -> {
+                if (entry.getValue() == null || entry.getValue() < 0) {
+                    throw new BadRequestException("남은 정원은 0 이상이어야 합니다.");
+                }
+                result.put(entry.getKey(), new LinkedHashSet<>());
+            });
+        for (Position position : Position.values()) {
+            List<Long> members = new ArrayList<>(clusters.entrySet().stream()
+                .filter(e -> e.getValue() == position).map(Map.Entry::getKey).sorted().toList());
+            List<Slot> slots = new ArrayList<>(result.keySet().stream()
+                .filter(s -> s.position() == position && vacancies.get(s) > 0).toList());
+            shuffle(members, random);
+            shuffle(slots, random);
+            int cursor = 0;
+            // Cycle through projects so a single project does not consume the whole field first.
+            while (cursor < members.size() && !slots.isEmpty()) {
+                Iterator<Slot> iterator = slots.iterator();
+                while (iterator.hasNext() && cursor < members.size()) {
+                    Slot slot = iterator.next();
+                    result.get(slot).add(members.get(cursor++));
+                    if (result.get(slot).size() >= vacancies.get(slot)) iterator.remove();
+                }
+            }
+        }
+        return result;
+    }
+    private <T> void shuffle(List<T> values, RandomGenerator random) {
+        for (int i = values.size() - 1; i > 0; i--) Collections.swap(values, i, random.nextInt(i + 1));
+    }
+}

--- a/server/src/main/java/wap/web2/server/teambuild/service/RecruitmentPolicy.java
+++ b/server/src/main/java/wap/web2/server/teambuild/service/RecruitmentPolicy.java
@@ -1,0 +1,56 @@
+package wap.web2.server.teambuild.service;
+
+import java.util.*;
+import wap.web2.server.exception.BadRequestException;
+import wap.web2.server.teambuild.dto.RecruitmentDto.RecruitmentInfo;
+import wap.web2.server.teambuild.entity.Position;
+import wap.web2.server.teambuild.entity.ProjectApply;
+
+/** Counts people across all positions; multiple applications by one person count once. */
+public final class RecruitmentPolicy {
+    private RecruitmentPolicy() {}
+
+    public static void validate(List<RecruitmentInfo> rosters, List<ProjectApply> applies, int round) {
+        if (round != 1 && round != 2) {
+            throw new BadRequestException("지원 및 모집 차수는 1 또는 2여야 합니다.");
+        }
+        if (rosters == null) {
+            throw new BadRequestException("모집 목록이 필요합니다.");
+        }
+        Map<Position, Set<Long>> eligible = new EnumMap<>(Position.class);
+        Set<Long> applicants = new HashSet<>();
+        for (ProjectApply apply : applies) {
+            Long id = apply.getUser().getId();
+            applicants.add(id);
+            eligible.computeIfAbsent(apply.getPosition(), key -> new HashSet<>()).add(id);
+        }
+        Set<Position> positions = EnumSet.noneOf(Position.class);
+        Set<Long> selected = new HashSet<>();
+        for (RecruitmentInfo roster : rosters) {
+            if (roster == null || roster.getCapacity() == null || roster.getCapacity() < 0 ||
+                roster.getApplicantIds() == null) {
+                throw new BadRequestException("모집 정원은 0 이상이며 지원자 목록이 필요합니다.");
+            }
+            Position position;
+            try {
+                position = Position.valueOf(roster.getPosition().toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException | NullPointerException e) {
+                throw new BadRequestException("유효하지 않은 포지션입니다.");
+            }
+            if (!positions.add(position)) {
+                throw new BadRequestException("직무별 모집 정보는 한 번만 제출할 수 있습니다.");
+            }
+            Set<Long> inPosition = new HashSet<>();
+            for (Long id : roster.getApplicantIds()) {
+                if (id == null || !inPosition.add(id) ||
+                    !eligible.getOrDefault(position, Set.of()).contains(id)) {
+                    throw new BadRequestException("해당 차수와 직무의 지원자를 중복 없이 선택해야 합니다.");
+                }
+                selected.add(id);
+            }
+        }
+        if (round == 1 && selected.size() < Math.min(4, applicants.size())) {
+            throw new BadRequestException("1차 모집은 지원자 4명 이상을 선택해야 하며, 4명 미만이면 모두 선택해야 합니다.");
+        }
+    }
+}

--- a/server/src/main/java/wap/web2/server/teambuild/service/TeamBuildingResultService.java
+++ b/server/src/main/java/wap/web2/server/teambuild/service/TeamBuildingResultService.java
@@ -27,6 +27,7 @@ import wap.web2.server.teambuild.repository.TeamRepository;
 @RequiredArgsConstructor
 public class TeamBuildingResultService {
 
+    private final wap.web2.server.member.repository.UserRepository userRepository;
     private final TeamRepository teamRepository;
     private final ProjectRepository projectRepository;
     private final ProjectApplyRepository projectApplyRepository;
@@ -60,7 +61,15 @@ public class TeamBuildingResultService {
                 projectId,
                 Collections.emptyList()
             );
-            List<TeamMemberResult> members = buildAssignedMembers(projectId, semester, memberIds);
+            Map<Long, wap.web2.server.member.entity.User> users = userRepository.findAllById(memberIds).stream()
+                .collect(Collectors.toMap(wap.web2.server.member.entity.User::getId, u -> u));
+            List<TeamMemberResult> members = teams.stream()
+                .filter(t -> t.getProjectId().equals(projectId))
+                .map(t -> {
+                    var user = users.get(t.getMemberId());
+                    if (user == null) throw new wap.web2.server.exception.ResourceNotFoundException("배정된 사용자를 찾을 수 없습니다.");
+                    return new TeamMemberResult(user.getId(), user.getName(), t.getPosition());
+                }).toList();
 
             // 리더 정보
             TeamMemberResult leader = TeamMemberResult.fromLeader(project.getUser());
@@ -71,25 +80,6 @@ public class TeamBuildingResultService {
         }
 
         return results;
-    }
-
-    private List<TeamMemberResult> buildAssignedMembers(
-        Long projectId,
-        String semester,
-        List<Long> memberIds
-    ) {
-        if (memberIds.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        List<ProjectApply> assignedApplies =
-            projectApplyRepository.findByProject_ProjectIdAndSemesterAndUser_IdInOrderByPriorityAsc(
-                projectId,
-                semester,
-                memberIds
-            );
-
-        return assignedApplies.stream().map(TeamMemberResult::from).toList();
     }
 
     @Transactional(readOnly = true)

--- a/server/src/main/resources/db/migration/V5__add_team_building_round.sql
+++ b/server/src/main/resources/db/migration/V5__add_team_building_round.sql
@@ -1,0 +1,8 @@
+-- Existing applications and recruitment preferences belong to the first round.
+ALTER TABLE project_apply ADD COLUMN round INT NOT NULL DEFAULT 1;
+ALTER TABLE project_recruit ADD COLUMN round INT NOT NULL DEFAULT 1;
+
+CREATE INDEX idx_project_apply_project_semester_round
+    ON project_apply (project_id, semester, round);
+CREATE INDEX idx_project_recruit_project_semester_round
+    ON project_recruit (project_id, semester, round);

--- a/server/src/main/resources/db/migration/V6__track_team_building_progress.sql
+++ b/server/src/main/resources/db/migration/V6__track_team_building_progress.sql
@@ -1,0 +1,6 @@
+ALTER TABLE team_building_meta ADD COLUMN round INT NOT NULL DEFAULT 1;
+ALTER TABLE team_building_meta ADD COLUMN completed_round INT NOT NULL DEFAULT 0;
+ALTER TABLE team ADD COLUMN round INT NOT NULL DEFAULT 1;
+-- Existing teams have already been allocated in round one.
+UPDATE team_building_meta m SET completed_round = 1
+WHERE EXISTS (SELECT 1 FROM team t WHERE t.semester = m.semester);

--- a/server/src/main/resources/db/migration/V7__create_field_clusters.sql
+++ b/server/src/main/resources/db/migration/V7__create_field_clusters.sql
@@ -1,0 +1,7 @@
+CREATE TABLE field_cluster_member (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    semester VARCHAR(7) NOT NULL,
+    user_id BIGINT NOT NULL,
+    position ENUM('FRONTEND','BACKEND','AI','DESIGN','APP','GAME','EMBEDDED') NOT NULL,
+    CONSTRAINT uk_field_cluster_semester_user UNIQUE (semester, user_id)
+);

--- a/server/src/test/java/wap/web2/server/admin/service/AdminTeamBuildingRoundTest.java
+++ b/server/src/test/java/wap/web2/server/admin/service/AdminTeamBuildingRoundTest.java
@@ -1,28 +1,22 @@
 package wap.web2.server.admin.service;
 
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 import static wap.web2.server.util.SemesterGenerator.generateSemester;
-
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
-import wap.web2.server.admin.entity.TeamBuildingMeta;
-import wap.web2.server.admin.entity.TeamBuildingStatus;
+import wap.web2.server.admin.entity.*;
 import wap.web2.server.admin.repository.TeamBuildingMetaRepository;
+import wap.web2.server.exception.ConflictException;
 import wap.web2.server.member.entity.User;
 import wap.web2.server.project.entity.Project;
 import wap.web2.server.project.repository.ProjectRepository;
-import wap.web2.server.teambuild.entity.Position;
-import wap.web2.server.teambuild.entity.ProjectApply;
-import wap.web2.server.teambuild.repository.ProjectApplyRepository;
-import wap.web2.server.teambuild.repository.ProjectRecruitRepository;
-import wap.web2.server.teambuild.repository.TeamRepository;
-import wap.web2.server.teambuild.service.TeamBuilder;
+import wap.web2.server.teambuild.entity.*;
+import wap.web2.server.teambuild.repository.*;
+import wap.web2.server.teambuild.service.PositionTeamBuilder;
 
 @ExtendWith(MockitoExtension.class)
 class AdminTeamBuildingRoundTest {
@@ -31,28 +25,40 @@ class AdminTeamBuildingRoundTest {
     @Mock ProjectApplyRepository applyRepository;
     @Mock ProjectRepository projectRepository;
     @Mock TeamRepository teamRepository;
-    @Mock TeamBuilder teamBuilder;
+    @Mock PositionTeamBuilder teamBuilder;
     @InjectMocks AdminTeamBuildingService service;
 
-    @Test
-    void existingAllocationReadsOnlyFirstRoundApplicationsAndRecruitments() {
+    @Test void secondRoundPreservesExistingMembersAndCannotBeRunTwice() {
         String semester = generateSemester();
-        when(teamBuildingMetaRepository.findBySemester(semester)).thenReturn(Optional.of(
-            new TeamBuildingMeta(1L, semester, TeamBuildingStatus.CLOSED)));
-        User user = new User();
-        user.setId(1L);
-        Project project = Project.builder().projectId(10L).build();
-        for (Position position : Position.values()) {
-            when(applyRepository.findAllBySemesterAndRoundAndPosition(semester, 1, position))
-                .thenReturn(List.of(ProjectApply.builder().user(user).project(project)
-                    .priority(1).position(position).build()));
-        }
-
+        TeamBuildingMeta meta = new TeamBuildingMeta(2, 1, 1L, semester, TeamBuildingStatus.CLOSED);
+        when(teamBuildingMetaRepository.findBySemesterForUpdate(semester)).thenReturn(Optional.of(meta));
+        User leader = new User(); leader.setId(10L);
+        when(projectRepository.findProjectsBySemester(semester)).thenReturn(List.of(
+            Project.builder().projectId(100L).user(leader).build()));
+        when(teamRepository.findAllBySemester(semester)).thenReturn(List.of(Team.builder().memberId(20L).build()));
+        when(teamBuilder.allocate(List.of(), List.of(), Set.of(10L, 20L))).thenReturn(Map.of(
+            new PositionTeamBuilder.Slot(100L, Position.AI), Set.of(30L)));
         service.makeTeam();
+        verify(applyRepository).findAllBySemesterAndRound(semester, 2);
+        verify(recruitRepository).findAllBySemesterAndRound(semester, 2);
+        ArgumentCaptor<List<Team>> teams = ArgumentCaptor.forClass(List.class);
+        verify(teamRepository).saveAll(teams.capture());
+        assertThat(teams.getValue()).singleElement().satisfies(t -> {
+            assertThat(t.getMemberId()).isEqualTo(30L); assertThat(t.getRound()).isEqualTo(2);
+        });
+        assertThatThrownBy(service::makeTeam).isInstanceOf(ConflictException.class);
+    }
 
-        for (Position position : Position.values()) {
-            verify(applyRepository).findAllBySemesterAndRoundAndPosition(semester, 1, position);
-            verify(recruitRepository).findAllBySemesterAndRoundAndPosition(semester, 1, position);
-        }
+    @Test void reopeningAfterCompletedFirstRoundAdvancesToSecondRound() {
+        TeamBuildingMeta meta = new TeamBuildingMeta(1L, "2026-02", TeamBuildingStatus.CLOSED);
+        meta.changeStatus(TeamBuildingStatus.APPLY);
+        assertThat(meta.getRound()).isEqualTo(1);
+        meta.changeStatus(TeamBuildingStatus.CLOSED);
+        meta.completeRound();
+        meta.changeStatus(TeamBuildingStatus.APPLY);
+        assertThat(meta.getRound()).isEqualTo(2);
+        meta.changeStatus(TeamBuildingStatus.CLOSED);
+        meta.completeRound();
+        assertThatThrownBy(() -> meta.changeStatus(TeamBuildingStatus.APPLY)).isInstanceOf(ConflictException.class);
     }
 }

--- a/server/src/test/java/wap/web2/server/admin/service/AdminTeamBuildingRoundTest.java
+++ b/server/src/test/java/wap/web2/server/admin/service/AdminTeamBuildingRoundTest.java
@@ -1,0 +1,58 @@
+package wap.web2.server.admin.service;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static wap.web2.server.util.SemesterGenerator.generateSemester;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import wap.web2.server.admin.entity.TeamBuildingMeta;
+import wap.web2.server.admin.entity.TeamBuildingStatus;
+import wap.web2.server.admin.repository.TeamBuildingMetaRepository;
+import wap.web2.server.member.entity.User;
+import wap.web2.server.project.entity.Project;
+import wap.web2.server.project.repository.ProjectRepository;
+import wap.web2.server.teambuild.entity.Position;
+import wap.web2.server.teambuild.entity.ProjectApply;
+import wap.web2.server.teambuild.repository.ProjectApplyRepository;
+import wap.web2.server.teambuild.repository.ProjectRecruitRepository;
+import wap.web2.server.teambuild.repository.TeamRepository;
+import wap.web2.server.teambuild.service.TeamBuilder;
+
+@ExtendWith(MockitoExtension.class)
+class AdminTeamBuildingRoundTest {
+    @Mock TeamBuildingMetaRepository teamBuildingMetaRepository;
+    @Mock ProjectRecruitRepository recruitRepository;
+    @Mock ProjectApplyRepository applyRepository;
+    @Mock ProjectRepository projectRepository;
+    @Mock TeamRepository teamRepository;
+    @Mock TeamBuilder teamBuilder;
+    @InjectMocks AdminTeamBuildingService service;
+
+    @Test
+    void existingAllocationReadsOnlyFirstRoundApplicationsAndRecruitments() {
+        String semester = generateSemester();
+        when(teamBuildingMetaRepository.findBySemester(semester)).thenReturn(Optional.of(
+            new TeamBuildingMeta(1L, semester, TeamBuildingStatus.CLOSED)));
+        User user = new User();
+        user.setId(1L);
+        Project project = Project.builder().projectId(10L).build();
+        for (Position position : Position.values()) {
+            when(applyRepository.findAllBySemesterAndRoundAndPosition(semester, 1, position))
+                .thenReturn(List.of(ProjectApply.builder().user(user).project(project)
+                    .priority(1).position(position).build()));
+        }
+
+        service.makeTeam();
+
+        for (Position position : Position.values()) {
+            verify(applyRepository).findAllBySemesterAndRoundAndPosition(semester, 1, position);
+            verify(recruitRepository).findAllBySemesterAndRoundAndPosition(semester, 1, position);
+        }
+    }
+}

--- a/server/src/test/java/wap/web2/server/admin/service/ThirdRoundTeamBuildingServiceTest.java
+++ b/server/src/test/java/wap/web2/server/admin/service/ThirdRoundTeamBuildingServiceTest.java
@@ -1,0 +1,85 @@
+package wap.web2.server.admin.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static wap.web2.server.util.SemesterGenerator.generateSemester;
+import java.util.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import wap.web2.server.admin.entity.*;
+import wap.web2.server.admin.repository.TeamBuildingMetaRepository;
+import wap.web2.server.exception.*;
+import wap.web2.server.member.entity.User;
+import wap.web2.server.project.entity.Project;
+import wap.web2.server.project.repository.ProjectRepository;
+import wap.web2.server.teambuild.entity.*;
+import wap.web2.server.teambuild.repository.*;
+import wap.web2.server.teambuild.service.*;
+
+@ExtendWith(MockitoExtension.class)
+class ThirdRoundTeamBuildingServiceTest {
+    @Mock TeamBuildingMetaRepository metaRepository;
+    @Mock FieldClusterMemberRepository clusterRepository;
+    @Mock ProjectApplyRepository applyRepository;
+    @Mock ProjectRecruitRepository recruitRepository;
+    @Mock TeamRepository teamRepository;
+    @Mock ProjectRepository projectRepository;
+    @Spy FieldClusterer clusterer = new FieldClusterer();
+    @Spy RandomFieldTeamBuilder builder = new RandomFieldTeamBuilder();
+    @InjectMocks ThirdRoundTeamBuildingService service;
+
+    private TeamBuildingMeta ready() {
+        TeamBuildingMeta meta = new TeamBuildingMeta(2, 2, 1L, generateSemester(), TeamBuildingStatus.CLOSED);
+        when(metaRepository.findBySemesterForUpdate(generateSemester())).thenReturn(Optional.of(meta));
+        return meta;
+    }
+    private void candidates() {
+        User leader = new User(); leader.setId(10L);
+        Project project = Project.builder().projectId(100L).user(leader).build();
+        when(projectRepository.findProjectsBySemester(generateSemester())).thenReturn(List.of(project));
+        User user = new User(); user.setId(1L);
+        when(applyRepository.findAllBySemester(generateSemester())).thenReturn(List.of(
+            ProjectApply.builder().user(user).project(project).position(Position.AI).priority(1).round(2).build()));
+    }
+    @Test void manualCorrectionIsUsedForThirdRoundAndRepeatAllocationIsRejected() {
+        TeamBuildingMeta meta = ready(); candidates();
+        FieldClusterMember member = new FieldClusterMember(generateSemester(), 1L, Position.AI);
+        when(clusterRepository.findAllBySemesterOrderByUserId(generateSemester())).thenReturn(List.of(member));
+        service.updateClusters(Map.of(1L, Position.BACKEND));
+        assertThat(member.getPosition()).isEqualTo(Position.BACKEND);
+        when(recruitRepository.findAllBySemesterAndRound(generateSemester(), 1)).thenReturn(List.of());
+        when(recruitRepository.findAllBySemesterAndRound(generateSemester(), 2)).thenReturn(List.of(
+            ProjectRecruit.builder().projectId(100L).position(Position.BACKEND).capacity(1).round(2).build()));
+        service.allocate();
+        ArgumentCaptor<List<Team>> saved = ArgumentCaptor.forClass(List.class);
+        verify(teamRepository).saveAll(saved.capture());
+        assertThat(saved.getValue()).singleElement().satisfies(t -> {
+            assertThat(t.getMemberId()).isEqualTo(1L);
+            assertThat(t.getPosition()).isEqualTo(Position.BACKEND);
+            assertThat(t.getRound()).isEqualTo(3);
+        });
+        assertThat(meta.getCompletedRound()).isEqualTo(3);
+        assertThatThrownBy(service::allocate).isInstanceOf(ConflictException.class);
+    }
+    @Test void rejectsUnknownManualMemberBeforeChangingAnyCluster() {
+        ready(); candidates();
+        FieldClusterMember member = new FieldClusterMember(generateSemester(), 1L, Position.AI);
+        when(clusterRepository.findAllBySemesterOrderByUserId(generateSemester())).thenReturn(List.of(member));
+        assertThatThrownBy(() -> service.updateClusters(Map.of(1L, Position.BACKEND, 2L, Position.AI)))
+            .isInstanceOf(BadRequestException.class);
+        assertThat(member.getPosition()).isEqualTo(Position.AI);
+    }
+    @Test void requiresClusterGenerationBeforeAllocation() {
+        ready(); candidates();
+        assertThatThrownBy(service::allocate).isInstanceOf(ConflictException.class);
+        verify(teamRepository, never()).saveAll(any());
+    }
+    @Test void requiresSecondRoundCompletionBeforeRebuilding() {
+        when(metaRepository.findBySemesterForUpdate(generateSemester())).thenReturn(Optional.of(
+            new TeamBuildingMeta(1L, generateSemester(), TeamBuildingStatus.CLOSED)));
+        assertThatThrownBy(service::rebuildClusters).isInstanceOf(ConflictException.class);
+        verifyNoInteractions(clusterRepository);
+    }
+}

--- a/server/src/test/java/wap/web2/server/project/service/ApplyServiceTest.java
+++ b/server/src/test/java/wap/web2/server/project/service/ApplyServiceTest.java
@@ -58,7 +58,7 @@ class ApplyServiceTest {
         when(principal.getName()).thenReturn("tester");
 
         User user = new User();
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(user));
 
         Project p1 = Project.builder().projectId(10L).title("A").build();
         Project p2 = Project.builder().projectId(20L).title("B").build();
@@ -102,7 +102,7 @@ class ApplyServiceTest {
         owner.setId(1L);
         User other = new User();
         other.setId(2L);
-        // when(userRepository.findById(1L)).thenReturn(Optional.of(owner));
+        // when(userRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(owner));
         when(userRepository.findById(2L)).thenReturn(Optional.of(other));
 
         Project project = Project.builder()

--- a/server/src/test/java/wap/web2/server/project/service/ApplyServiceTest.java
+++ b/server/src/test/java/wap/web2/server/project/service/ApplyServiceTest.java
@@ -75,7 +75,7 @@ class ApplyServiceTest {
             )
         );
 
-        when(teamBuildingMetaRepository.findBySemester(generateSemester()))
+        when(teamBuildingMetaRepository.findBySemesterForUpdate(generateSemester()))
             .thenReturn(Optional.of(new TeamBuildingMeta(
                 1L, generateSemester(),
                 TeamBuildingStatus.APPLY)));

--- a/server/src/test/java/wap/web2/server/project/service/ApplyServiceTest.java
+++ b/server/src/test/java/wap/web2/server/project/service/ApplyServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static wap.web2.server.util.SemesterGenerator.generateSemester;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,6 +16,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import wap.web2.server.admin.entity.TeamBuildingMeta;
+import wap.web2.server.admin.entity.TeamBuildingStatus;
+import wap.web2.server.admin.repository.TeamBuildingMetaRepository;
+import wap.web2.server.exception.ForbiddenException;
 import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.member.entity.User;
 import wap.web2.server.member.repository.UserRepository;
@@ -29,6 +34,9 @@ import wap.web2.server.teambuild.service.ApplyService;
 
 @ExtendWith(MockitoExtension.class)
 class ApplyServiceTest {
+
+    @Mock
+    TeamBuildingMetaRepository teamBuildingMetaRepository;
 
     @Mock
     UserRepository userRepository;
@@ -67,6 +75,11 @@ class ApplyServiceTest {
             )
         );
 
+        when(teamBuildingMetaRepository.findBySemester(generateSemester()))
+            .thenReturn(Optional.of(new TeamBuildingMeta(
+                1L, generateSemester(),
+                TeamBuildingStatus.APPLY)));
+
         // when
         applyService.apply(principal, request);
 
@@ -101,7 +114,7 @@ class ApplyServiceTest {
 
         // when & then
         assertThatThrownBy(() -> applyService.getApplies(principal, 1L)).isInstanceOf(
-            IllegalArgumentException.class
+            ForbiddenException.class
         );
     }
 }

--- a/server/src/test/java/wap/web2/server/teambuild/service/ApplicationChoiceTest.java
+++ b/server/src/test/java/wap/web2/server/teambuild/service/ApplicationChoiceTest.java
@@ -1,0 +1,100 @@
+package wap.web2.server.teambuild.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static wap.web2.server.util.SemesterGenerator.generateSemester;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import wap.web2.server.admin.entity.*;
+import wap.web2.server.admin.repository.TeamBuildingMetaRepository;
+import wap.web2.server.exception.BadRequestException;
+import wap.web2.server.global.security.UserPrincipal;
+import wap.web2.server.member.entity.User;
+import wap.web2.server.member.repository.UserRepository;
+import wap.web2.server.project.entity.Project;
+import wap.web2.server.project.repository.ProjectRepository;
+import wap.web2.server.teambuild.dto.request.ProjectAppliesRequest;
+import wap.web2.server.teambuild.dto.request.ProjectAppliesRequest.ApplyRequest;
+import wap.web2.server.teambuild.dto.response.ProjectAppliesResponse;
+import wap.web2.server.teambuild.entity.*;
+import wap.web2.server.teambuild.repository.ProjectApplyRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationChoiceTest {
+    @Mock TeamBuildingMetaRepository teamBuildingMetaRepository;
+    @Mock UserRepository userRepository;
+    @Mock ProjectRepository projectRepository;
+    @Mock ProjectApplyRepository applyRepository;
+    @InjectMocks ApplyService service;
+
+    private UserPrincipal applicant() {
+        UserPrincipal principal = mock(UserPrincipal.class);
+        when(principal.getId()).thenReturn(1L);
+        User user = new User();
+        user.setId(1L);
+        when(userRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(user));
+        when(teamBuildingMetaRepository.findBySemester(generateSemester())).thenReturn(Optional.of(
+            new TeamBuildingMeta(1L, generateSemester(), TeamBuildingStatus.APPLY)));
+        return principal;
+    }
+
+    @Test
+    void acceptsFiveProjectPositionPairsAcrossTwoProjects() {
+        UserPrincipal principal = applicant();
+        when(projectRepository.findById(anyLong())).thenAnswer(i -> Optional.of(
+            Project.builder().projectId(i.getArgument(0)).build()));
+        service.apply(principal, new ProjectAppliesRequest(List.of(
+            new ApplyRequest(10L, "frontend", "a"), new ApplyRequest(10L, "backend", "b"),
+            new ApplyRequest(20L, "frontend", "c"), new ApplyRequest(20L, "backend", "d"),
+            new ApplyRequest(20L, "AI", "e"))), 1);
+        ArgumentCaptor<ProjectApply> saved = ArgumentCaptor.forClass(ProjectApply.class);
+        verify(applyRepository, times(5)).save(saved.capture());
+        assertThat(saved.getAllValues()).extracting(ProjectApply::getPriority).containsExactly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    void rejectsDuplicatePairBeforeSavingAnything() {
+        UserPrincipal principal = applicant();
+        assertThatThrownBy(() -> service.apply(principal, new ProjectAppliesRequest(List.of(
+            new ApplyRequest(10L, "frontend", "a"), new ApplyRequest(10L, "FRONTEND", "b"))), 1))
+            .isInstanceOf(BadRequestException.class);
+        verify(applyRepository, never()).save(any());
+    }
+
+    @Test
+    void countsPreviouslySubmittedApplicationsInSameRound() {
+        UserPrincipal principal = applicant();
+        ProjectApply existing = ProjectApply.builder().project(Project.builder().projectId(10L).build())
+            .priority(1).position(Position.AI).build();
+        when(applyRepository.findAllByUserIdAndSemesterAndRound(1L, generateSemester(), 2))
+            .thenReturn(java.util.Collections.nCopies(5, existing));
+        assertThatThrownBy(() -> service.apply(principal, new ProjectAppliesRequest(List.of(
+            new ApplyRequest(20L, "AI", "a"))), 2)).isInstanceOf(BadRequestException.class);
+        verify(applyRepository, never()).save(any());
+    }
+
+    @Test
+    void experienceIsSavedAndReturnedWhileCareerRemainsCompatible() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        ProjectAppliesRequest request = mapper.readValue(
+            """
+            { "applies": [{"projectId":10,"position":"frontend","comment":"a","experience":"React"}] }""",
+            ProjectAppliesRequest.class);
+        UserPrincipal principal = applicant();
+        when(projectRepository.findById(10L)).thenReturn(Optional.of(Project.builder().projectId(10L).build()));
+        service.apply(principal, request, 1);
+        ArgumentCaptor<ProjectApply> saved = ArgumentCaptor.forClass(ProjectApply.class);
+        verify(applyRepository).save(saved.capture());
+        assertThat(saved.getValue().getCareer()).isEqualTo("React");
+        var json = mapper.valueToTree(ProjectAppliesResponse.fromEntities(List.of(saved.getValue())));
+        assertThat(json.at("/applies/0/experience").asText()).isEqualTo("React");
+        assertThat(json.at("/applies/0/career").asText()).isEqualTo("React");
+        assertThat(new ApplyRequest(10L, "AI", "a", "legacy").getExperience()).isEqualTo("legacy");
+    }
+}

--- a/server/src/test/java/wap/web2/server/teambuild/service/ApplicationChoiceTest.java
+++ b/server/src/test/java/wap/web2/server/teambuild/service/ApplicationChoiceTest.java
@@ -34,13 +34,17 @@ class ApplicationChoiceTest {
     @InjectMocks ApplyService service;
 
     private UserPrincipal applicant() {
+        return applicant(1);
+    }
+
+    private UserPrincipal applicant(int round) {
         UserPrincipal principal = mock(UserPrincipal.class);
         when(principal.getId()).thenReturn(1L);
         User user = new User();
         user.setId(1L);
         when(userRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(user));
         when(teamBuildingMetaRepository.findBySemester(generateSemester())).thenReturn(Optional.of(
-            new TeamBuildingMeta(1L, generateSemester(), TeamBuildingStatus.APPLY)));
+            new TeamBuildingMeta(round, 0, 1L, generateSemester(), TeamBuildingStatus.APPLY)));
         return principal;
     }
 
@@ -69,7 +73,7 @@ class ApplicationChoiceTest {
 
     @Test
     void countsPreviouslySubmittedApplicationsInSameRound() {
-        UserPrincipal principal = applicant();
+        UserPrincipal principal = applicant(2);
         ProjectApply existing = ProjectApply.builder().project(Project.builder().projectId(10L).build())
             .priority(1).position(Position.AI).build();
         when(applyRepository.findAllByUserIdAndSemesterAndRound(1L, generateSemester(), 2))

--- a/server/src/test/java/wap/web2/server/teambuild/service/ApplicationChoiceTest.java
+++ b/server/src/test/java/wap/web2/server/teambuild/service/ApplicationChoiceTest.java
@@ -43,7 +43,7 @@ class ApplicationChoiceTest {
         User user = new User();
         user.setId(1L);
         when(userRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(user));
-        when(teamBuildingMetaRepository.findBySemester(generateSemester())).thenReturn(Optional.of(
+        when(teamBuildingMetaRepository.findBySemesterForUpdate(generateSemester())).thenReturn(Optional.of(
             new TeamBuildingMeta(round, 0, 1L, generateSemester(), TeamBuildingStatus.APPLY)));
         return principal;
     }

--- a/server/src/test/java/wap/web2/server/teambuild/service/ApplyRoundTest.java
+++ b/server/src/test/java/wap/web2/server/teambuild/service/ApplyRoundTest.java
@@ -63,7 +63,7 @@ class ApplyRoundTest {
     }
 
     private void status(TeamBuildingStatus status, int round) {
-        when(teamBuildingMetaRepository.findBySemester(generateSemester()))
+        when(teamBuildingMetaRepository.findBySemesterForUpdate(generateSemester()))
             .thenReturn(Optional.of(new TeamBuildingMeta(round, 0, 1L, generateSemester(), status)));
     }
 
@@ -81,6 +81,7 @@ class ApplyRoundTest {
         ArgumentCaptor<ProjectApply> captor = ArgumentCaptor.forClass(ProjectApply.class);
         verify(applyRepository).save(captor.capture());
         assertThat(captor.getValue().getRound()).isEqualTo(round);
+        assertThat(captor.getValue().getSemester()).isEqualTo(generateSemester());
     }
 
     @ParameterizedTest
@@ -94,6 +95,31 @@ class ApplyRoundTest {
         ArgumentCaptor<ProjectRecruit> captor = ArgumentCaptor.forClass(ProjectRecruit.class);
         verify(recruitRepository).save(captor.capture());
         assertThat(captor.getValue().getRound()).isEqualTo(round);
+        assertThat(captor.getValue().getSemester()).isEqualTo(generateSemester());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2})
+    void rejectsClosedSubmissionsBeforeAccessingUserOrApplicationData(int round) {
+        status(TeamBuildingStatus.CLOSED, round);
+        assertThatThrownBy(() -> service.apply(principal, null, round))
+            .isInstanceOf(ConflictException.class);
+        assertThatThrownBy(() -> service.setPreference(principal, null, round))
+            .isInstanceOf(ConflictException.class);
+        verifyNoInteractions(userRepository, projectRepository, applyRepository,
+            recruitRepository, recruitWishRepository);
+    }
+
+    @Test
+    void rejectsStaleRoundAfterLockingMeta() {
+        status(TeamBuildingStatus.APPLY, 2);
+        assertThatThrownBy(() -> service.apply(principal, null, 1))
+            .isInstanceOf(ConflictException.class);
+        status(TeamBuildingStatus.RECRUIT, 2);
+        assertThatThrownBy(() -> service.setPreference(principal, null, 1))
+            .isInstanceOf(ConflictException.class);
+        verifyNoInteractions(userRepository, projectRepository, applyRepository,
+            recruitRepository, recruitWishRepository);
     }
 
     @Test

--- a/server/src/test/java/wap/web2/server/teambuild/service/ApplyRoundTest.java
+++ b/server/src/test/java/wap/web2/server/teambuild/service/ApplyRoundTest.java
@@ -1,0 +1,129 @@
+package wap.web2.server.teambuild.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static wap.web2.server.util.SemesterGenerator.generateSemester;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import wap.web2.server.admin.entity.TeamBuildingMeta;
+import wap.web2.server.admin.entity.TeamBuildingStatus;
+import wap.web2.server.admin.repository.TeamBuildingMetaRepository;
+import wap.web2.server.exception.BadRequestException;
+import wap.web2.server.exception.ConflictException;
+import wap.web2.server.global.security.UserPrincipal;
+import wap.web2.server.member.entity.User;
+import wap.web2.server.member.repository.UserRepository;
+import wap.web2.server.project.entity.Project;
+import wap.web2.server.project.repository.ProjectRepository;
+import wap.web2.server.teambuild.dto.RecruitmentDto;
+import wap.web2.server.teambuild.dto.request.ProjectAppliesRequest;
+import wap.web2.server.teambuild.entity.ProjectApply;
+import wap.web2.server.teambuild.entity.ProjectRecruit;
+import wap.web2.server.teambuild.repository.ProjectApplyRepository;
+import wap.web2.server.teambuild.repository.ProjectRecruitRepository;
+import wap.web2.server.teambuild.repository.ProjectRecruitWishRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ApplyRoundTest {
+    @Mock TeamBuildingMetaRepository teamBuildingMetaRepository;
+    @Mock ProjectRecruitWishRepository recruitWishRepository;
+    @Mock ProjectRecruitRepository recruitRepository;
+    @Mock ProjectApplyRepository applyRepository;
+    @Mock ProjectRepository projectRepository;
+    @Mock UserRepository userRepository;
+    @InjectMocks ApplyService service;
+
+    UserPrincipal principal;
+    Project project;
+
+    @BeforeEach
+    void setup() {
+        principal = mock(UserPrincipal.class);
+    }
+
+    private void owner() {
+        User user = new User();
+        user.setId(1L);
+        when(principal.getId()).thenReturn(1L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        project = Project.builder().projectId(10L).user(user).build();
+        when(projectRepository.findById(10L)).thenReturn(Optional.of(project));
+    }
+
+    private void status(TeamBuildingStatus status) {
+        when(teamBuildingMetaRepository.findBySemester(generateSemester()))
+            .thenReturn(Optional.of(new TeamBuildingMeta(1L, generateSemester(), status)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2})
+    void savesApplicationInRequestedRound(int round) {
+        owner();
+        status(TeamBuildingStatus.APPLY);
+        service.apply(principal, new ProjectAppliesRequest(List.of(
+            new ProjectAppliesRequest.ApplyRequest(10L, "BACKEND", "comment"))), round);
+        ArgumentCaptor<ProjectApply> captor = ArgumentCaptor.forClass(ProjectApply.class);
+        verify(applyRepository).save(captor.capture());
+        assertThat(captor.getValue().getRound()).isEqualTo(round);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2})
+    void savesRecruitmentInRequestedRound(int round) {
+        owner();
+        status(TeamBuildingStatus.RECRUIT);
+        when(recruitRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        service.setPreference(principal, new RecruitmentDto(10L, List.of(
+            new RecruitmentDto.RecruitmentInfo(2, "BACKEND", List.of()))), round);
+        ArgumentCaptor<ProjectRecruit> captor = ArgumentCaptor.forClass(ProjectRecruit.class);
+        verify(recruitRepository).save(captor.capture());
+        assertThat(captor.getValue().getRound()).isEqualTo(round);
+    }
+
+    @Test
+    void firstRoundRecruitmentDoesNotBlockSecondRoundPage() {
+        owner();
+        when(recruitRepository.existsByProjectIdAndSemesterAndRound(10L, generateSemester(), 1))
+            .thenReturn(true);
+        when(applyRepository.findAllByProjectAndSemesterAndRound(project, generateSemester(), 2))
+            .thenReturn(List.of());
+        assertThatThrownBy(() -> service.getRecruitPageData(principal, 10L, 1))
+            .isInstanceOf(ConflictException.class);
+        service.getRecruitPageData(principal, 10L, 2);
+        verify(applyRepository).findAllByProjectAndSemesterAndRound(project, generateSemester(), 2);
+        verify(applyRepository, never()).findAllByProject(any());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0, 3, 100})
+    void rejectsUnsupportedRoundsBeforeAccessingData(int round) {
+        assertThatThrownBy(() -> service.apply(principal, null, round)).isInstanceOf(BadRequestException.class);
+        assertThatThrownBy(() -> service.setPreference(principal, null, round)).isInstanceOf(BadRequestException.class);
+        assertThatThrownBy(() -> service.getRecruitPageData(principal, 10L, round)).isInstanceOf(BadRequestException.class);
+        verifyNoInteractions(teamBuildingMetaRepository, userRepository, applyRepository, recruitRepository);
+    }
+
+    @Test
+    void legacyPageUsesFirstRound() {
+        owner();
+        when(applyRepository.findAllByProjectAndSemesterAndRound(project, generateSemester(), 1))
+            .thenReturn(List.of());
+        service.getRecruitPageData(principal, 10L);
+        verify(recruitRepository).existsByProjectIdAndSemesterAndRound(10L, generateSemester(), 1);
+        verify(applyRepository).findAllByProjectAndSemesterAndRound(project, generateSemester(), 1);
+        assertThat(ProjectApply.builder().build().getRound()).isEqualTo(1);
+        assertThat(ProjectRecruit.builder().build().getRound()).isEqualTo(1);
+    }
+}

--- a/server/src/test/java/wap/web2/server/teambuild/service/ApplyRoundTest.java
+++ b/server/src/test/java/wap/web2/server/teambuild/service/ApplyRoundTest.java
@@ -62,9 +62,9 @@ class ApplyRoundTest {
         when(projectRepository.findById(10L)).thenReturn(Optional.of(project));
     }
 
-    private void status(TeamBuildingStatus status) {
+    private void status(TeamBuildingStatus status, int round) {
         when(teamBuildingMetaRepository.findBySemester(generateSemester()))
-            .thenReturn(Optional.of(new TeamBuildingMeta(1L, generateSemester(), status)));
+            .thenReturn(Optional.of(new TeamBuildingMeta(round, 0, 1L, generateSemester(), status)));
     }
 
     @ParameterizedTest
@@ -75,7 +75,7 @@ class ApplyRoundTest {
         when(principal.getId()).thenReturn(1L);
         when(userRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(user));
         when(projectRepository.findById(10L)).thenReturn(Optional.of(Project.builder().projectId(10L).build()));
-        status(TeamBuildingStatus.APPLY);
+        status(TeamBuildingStatus.APPLY, round);
         service.apply(principal, new ProjectAppliesRequest(List.of(
             new ProjectAppliesRequest.ApplyRequest(10L, "BACKEND", "comment"))), round);
         ArgumentCaptor<ProjectApply> captor = ArgumentCaptor.forClass(ProjectApply.class);
@@ -87,7 +87,7 @@ class ApplyRoundTest {
     @ValueSource(ints = {1, 2})
     void savesRecruitmentInRequestedRound(int round) {
         owner();
-        status(TeamBuildingStatus.RECRUIT);
+        status(TeamBuildingStatus.RECRUIT, round);
         when(recruitRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
         service.setPreference(principal, new RecruitmentDto(10L, List.of(
             new RecruitmentDto.RecruitmentInfo(2, "BACKEND", List.of()))), round);

--- a/server/src/test/java/wap/web2/server/teambuild/service/ApplyRoundTest.java
+++ b/server/src/test/java/wap/web2/server/teambuild/service/ApplyRoundTest.java
@@ -70,7 +70,11 @@ class ApplyRoundTest {
     @ParameterizedTest
     @ValueSource(ints = {1, 2})
     void savesApplicationInRequestedRound(int round) {
-        owner();
+        User user = new User();
+        user.setId(1L);
+        when(principal.getId()).thenReturn(1L);
+        when(userRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(user));
+        when(projectRepository.findById(10L)).thenReturn(Optional.of(Project.builder().projectId(10L).build()));
         status(TeamBuildingStatus.APPLY);
         service.apply(principal, new ProjectAppliesRequest(List.of(
             new ProjectAppliesRequest.ApplyRequest(10L, "BACKEND", "comment"))), round);

--- a/server/src/test/java/wap/web2/server/teambuild/service/FieldClusteringTest.java
+++ b/server/src/test/java/wap/web2/server/teambuild/service/FieldClusteringTest.java
@@ -1,0 +1,46 @@
+package wap.web2.server.teambuild.service;
+
+import static org.assertj.core.api.Assertions.*;
+import java.util.*;
+import org.junit.jupiter.api.Test;
+import wap.web2.server.member.entity.User;
+import wap.web2.server.project.entity.Project;
+import wap.web2.server.teambuild.entity.*;
+import wap.web2.server.teambuild.service.PositionTeamBuilder.Slot;
+
+class FieldClusteringTest {
+    private ProjectApply apply(long id, int round, int priority, Position position) {
+        User user = new User(); user.setId(id);
+        return ProjectApply.builder().user(user).project(Project.builder().projectId(10L).build())
+            .round(round).priority(priority).position(position).build();
+    }
+    @Test void clusteringIsOrderIndependentAndPrefersLatestRoundThenFirstChoice() {
+        List<ProjectApply> applies = new ArrayList<>(List.of(apply(1, 1, 1, Position.AI),
+            apply(1, 2, 2, Position.BACKEND), apply(1, 2, 1, Position.FRONTEND),
+            apply(2, 1, 1, Position.AI), apply(3, 1, 1, Position.AI)));
+        var expected = Map.of(1L, Position.FRONTEND, 2L, Position.AI);
+        assertThat(new FieldClusterer().cluster(applies, Set.of(3L))).isEqualTo(expected);
+        Collections.reverse(applies);
+        assertThat(new FieldClusterer().cluster(applies, Set.of(3L))).isEqualTo(expected);
+    }
+    @Test void randomAllocationRespectsFieldsCapacitiesAndUniqueMembership() {
+        Map<Long, Position> clusters = new HashMap<>();
+        for (long i = 1; i <= 20; i++) clusters.put(i, i <= 10 ? Position.AI : Position.BACKEND);
+        Map<Slot, Integer> vacancies = Map.of(new Slot(10L, Position.AI), 3,
+            new Slot(20L, Position.AI), 3, new Slot(10L, Position.BACKEND), 2);
+        Set<Map<Slot, Set<Long>>> outcomes = new HashSet<>();
+        for (int seed = 0; seed < 20; seed++) {
+            var allocation = new RandomFieldTeamBuilder().allocate(clusters, vacancies, new Random(seed));
+            outcomes.add(allocation);
+            Set<Long> selected = new HashSet<>();
+            allocation.forEach((slot, ids) -> {
+                assertThat(ids).hasSize(vacancies.get(slot));
+                ids.forEach(id -> {
+                    assertThat(selected.add(id)).isTrue();
+                    assertThat(clusters.get(id)).isEqualTo(slot.position());
+                });
+            });
+        }
+        assertThat(outcomes.size()).isGreaterThan(1);
+    }
+}

--- a/server/src/test/java/wap/web2/server/teambuild/service/PositionTeamBuilderTest.java
+++ b/server/src/test/java/wap/web2/server/teambuild/service/PositionTeamBuilderTest.java
@@ -1,0 +1,39 @@
+package wap.web2.server.teambuild.service;
+
+import static org.assertj.core.api.Assertions.*;
+import java.util.*;
+import org.junit.jupiter.api.Test;
+import wap.web2.server.member.entity.User;
+import wap.web2.server.project.entity.Project;
+import wap.web2.server.teambuild.entity.*;
+
+class PositionTeamBuilderTest {
+    private ProjectApply apply(long userId, long projectId, Position position, int priority) {
+        User user = new User(); user.setId(userId);
+        return ProjectApply.builder().user(user).project(Project.builder().projectId(projectId).build())
+            .position(position).priority(priority).build();
+    }
+    private ProjectRecruit recruit(long projectId, Position position, Long... ids) {
+        List<ProjectRecruitWish> wishes = new ArrayList<>();
+        for (Long id : ids) wishes.add(ProjectRecruitWish.builder().applicantId(id).priority(wishes.size() + 1).build());
+        return ProjectRecruit.builder().projectId(projectId).position(position).capacity(1).wishList(wishes).build();
+    }
+    @Test void resolvesCrossPositionDuplicatesAndBackfillsVacanciesUsingApplicantPriority() {
+        List<ProjectApply> applies = List.of(apply(1, 10, Position.AI, 2), apply(1, 10, Position.BACKEND, 1),
+            apply(2, 10, Position.AI, 1), apply(3, 20, Position.AI, 1));
+        List<ProjectRecruit> recruits = List.of(recruit(10, Position.AI, 1L, 2L),
+            recruit(10, Position.BACKEND, 1L), recruit(20, Position.AI, 3L));
+        var result = new PositionTeamBuilder().allocate(applies, recruits, Set.of(3L));
+        assertThat(result.get(new PositionTeamBuilder.Slot(10L, Position.AI))).containsExactly(2L);
+        assertThat(result.get(new PositionTeamBuilder.Slot(10L, Position.BACKEND))).containsExactly(1L);
+        assertThat(result.get(new PositionTeamBuilder.Slot(20L, Position.AI))).isEmpty();
+        assertThat(recruits.get(0).getWishList()).hasSize(2);
+        List<ProjectApply> reversed = new ArrayList<>(applies); Collections.reverse(reversed);
+        assertThat(new PositionTeamBuilder().allocate(reversed, recruits, Set.of(3L))).isEqualTo(result);
+    }
+    @Test void neverAllocatesSomeoneWithoutAnApplicationForTheSelectedPosition() {
+        var result = new PositionTeamBuilder().allocate(List.of(apply(1, 10, Position.AI, 1)),
+            List.of(recruit(10, Position.BACKEND, 1L)), Set.of());
+        assertThat(result.values()).allMatch(Set::isEmpty);
+    }
+}

--- a/server/src/test/java/wap/web2/server/teambuild/service/RecruitmentPolicyTest.java
+++ b/server/src/test/java/wap/web2/server/teambuild/service/RecruitmentPolicyTest.java
@@ -1,0 +1,50 @@
+package wap.web2.server.teambuild.service;
+
+import static org.assertj.core.api.Assertions.*;
+import java.util.*;
+import org.junit.jupiter.api.Test;
+import wap.web2.server.exception.BadRequestException;
+import wap.web2.server.member.entity.User;
+import wap.web2.server.teambuild.dto.RecruitmentDto.RecruitmentInfo;
+import wap.web2.server.teambuild.entity.*;
+
+class RecruitmentPolicyTest {
+    private ProjectApply apply(long id, Position position) {
+        User user = new User(); user.setId(id);
+        return ProjectApply.builder().user(user).position(position).build();
+    }
+    private RecruitmentInfo roster(String position, Long... ids) {
+        return new RecruitmentInfo(2, position, List.of(ids));
+    }
+    @Test void firstRoundCountsDistinctPeopleAcrossPositions() {
+        List<ProjectApply> applies = List.of(apply(1, Position.AI), apply(1, Position.BACKEND),
+            apply(2, Position.AI), apply(3, Position.BACKEND), apply(4, Position.BACKEND), apply(5, Position.AI));
+        assertThatThrownBy(() -> RecruitmentPolicy.validate(List.of(roster("AI", 1L, 2L),
+            roster("BACKEND", 1L, 3L)), applies, 1)).isInstanceOf(BadRequestException.class);
+        assertThatCode(() -> RecruitmentPolicy.validate(List.of(roster("AI", 1L, 2L),
+            roster("BACKEND", 3L, 4L)), applies, 1)).doesNotThrowAnyException();
+    }
+    @Test void fewerThanFourRequiresEveryoneButNotEveryApplication() {
+        List<ProjectApply> applies = List.of(apply(1, Position.AI), apply(1, Position.BACKEND), apply(2, Position.AI));
+        assertThatThrownBy(() -> RecruitmentPolicy.validate(List.of(roster("AI", 1L)), applies, 1))
+            .isInstanceOf(BadRequestException.class);
+        assertThatCode(() -> RecruitmentPolicy.validate(List.of(roster("AI", 1L, 2L)), applies, 1))
+            .doesNotThrowAnyException();
+    }
+    @Test void secondRoundAllowsNoneSomeOrAll() {
+        List<ProjectApply> applies = List.of(apply(1, Position.AI), apply(2, Position.AI));
+        for (List<RecruitmentInfo> rosters : List.of(List.<RecruitmentInfo>of(),
+            List.of(roster("AI", 1L)), List.of(roster("AI", 1L, 2L)))) {
+            assertThatCode(() -> RecruitmentPolicy.validate(rosters, applies, 2)).doesNotThrowAnyException();
+        }
+    }
+    @Test void rejectsWrongPositionUnknownApplicantAndDuplicateIdsInBothRounds() {
+        List<ProjectApply> applies = List.of(apply(1, Position.AI));
+        for (int round : List.of(1, 2)) {
+            for (RecruitmentInfo roster : List.of(roster("BACKEND", 1L), roster("AI", 2L), roster("AI", 1L, 1L))) {
+                assertThatThrownBy(() -> RecruitmentPolicy.validate(List.of(roster), applies, round))
+                    .isInstanceOf(BadRequestException.class);
+            }
+        }
+    }
+}

--- a/server/src/test/java/wap/web2/server/teambuild/service/SubmissionLockIntegrationTest.java
+++ b/server/src/test/java/wap/web2/server/teambuild/service/SubmissionLockIntegrationTest.java
@@ -1,0 +1,183 @@
+package wap.web2.server.teambuild.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static wap.web2.server.util.SemesterGenerator.generateSemester;
+
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.data.jpa.repository.support.JpaRepositoryFactory;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.SharedEntityManagerCreator;
+import org.springframework.orm.jpa.persistenceunit.PersistenceManagedTypes;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.transaction.annotation.AnnotationTransactionAttributeSource;
+import org.springframework.transaction.interceptor.TransactionInterceptor;
+import wap.web2.server.admin.entity.TeamBuildingMeta;
+import wap.web2.server.admin.entity.TeamBuildingStatus;
+import wap.web2.server.admin.repository.TeamBuildingMetaRepository;
+import wap.web2.server.exception.ConflictException;
+import wap.web2.server.global.security.UserPrincipal;
+import wap.web2.server.member.entity.User;
+import wap.web2.server.member.repository.UserRepository;
+import wap.web2.server.project.entity.Project;
+import wap.web2.server.project.repository.ProjectRepository;
+import wap.web2.server.teambuild.dto.RecruitmentDto;
+import wap.web2.server.teambuild.dto.request.ProjectAppliesRequest;
+import wap.web2.server.teambuild.repository.ProjectApplyRepository;
+import wap.web2.server.teambuild.repository.ProjectRecruitRepository;
+import wap.web2.server.teambuild.repository.ProjectRecruitWishRepository;
+
+/** Uses a disposable MySQL database: the team_building_meta table is recreated.
+ * Set TEAM_BUILD_LOCK_TEST_URL, optionally TEAM_BUILD_LOCK_TEST_USER/PASSWORD.
+ * Only meta persistence is real; submission repositories expose transaction checkpoints.
+ */
+@EnabledIfEnvironmentVariable(named = "TEAM_BUILD_LOCK_TEST_URL", matches = ".+")
+class SubmissionLockIntegrationTest {
+    private LocalContainerEntityManagerFactoryBean factory;
+    private EntityManager entityManager;
+    private TransactionTemplate transaction;
+    private TeamBuildingMetaRepository metas;
+    private final UserRepository users = mock(UserRepository.class);
+    private final ProjectRepository projects = mock(ProjectRepository.class);
+    private final ProjectApplyRepository applies = mock(ProjectApplyRepository.class);
+    private final ProjectRecruitRepository recruits = mock(ProjectRecruitRepository.class);
+    private final ProjectRecruitWishRepository wishes = mock(ProjectRecruitWishRepository.class);
+    private final UserPrincipal principal = mock(UserPrincipal.class);
+    private final ExecutorService executor = Executors.newFixedThreadPool(2);
+    private final CountDownLatch release = new CountDownLatch(1);
+    private ApplyService service;
+
+    @BeforeEach
+    void setup() {
+        var env = System.getenv();
+        factory = new LocalContainerEntityManagerFactoryBean();
+        factory.setDataSource(new DriverManagerDataSource(env.get("TEAM_BUILD_LOCK_TEST_URL"),
+            env.getOrDefault("TEAM_BUILD_LOCK_TEST_USER", "root"),
+            env.getOrDefault("TEAM_BUILD_LOCK_TEST_PASSWORD", "")));
+        factory.setManagedTypes(PersistenceManagedTypes.of(TeamBuildingMeta.class.getName()));
+        factory.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
+        factory.setJpaPropertyMap(Map.of("hibernate.hbm2ddl.auto", "create-drop"));
+        factory.afterPropertiesSet();
+        entityManager = SharedEntityManagerCreator.createSharedEntityManager(factory.getObject());
+        metas = new JpaRepositoryFactory(entityManager).getRepository(TeamBuildingMetaRepository.class);
+        var transactionManager = new JpaTransactionManager(factory.getObject());
+        transaction = new TransactionTemplate(transactionManager);
+        var proxy = new ProxyFactory(new ApplyService(metas, wishes, recruits, applies, projects, users));
+        proxy.addAdvice(new TransactionInterceptor(transactionManager, new AnnotationTransactionAttributeSource()));
+        service = (ApplyService) proxy.getProxy();
+        User user = new User();
+        user.setId(1L);
+        when(principal.getId()).thenReturn(1L);
+        when(users.findByIdForUpdate(1L)).thenReturn(Optional.of(user));
+        when(users.findById(1L)).thenReturn(Optional.of(user));
+        when(projects.findById(10L)).thenReturn(Optional.of(
+            Project.builder().projectId(10L).user(user).build()));
+        when(recruits.save(any())).thenAnswer(call -> call.getArgument(0));
+    }
+
+    @AfterEach
+    void cleanup() throws InterruptedException {
+        release.countDown();
+        executor.shutdownNow();
+        executor.awaitTermination(10, TimeUnit.SECONDS);
+        if (factory != null) factory.destroy();
+    }
+
+    private void initialize(TeamBuildingStatus status) {
+        transaction.executeWithoutResult(ignored ->
+            metas.save(new TeamBuildingMeta(2, 1, null, generateSemester(), status)));
+    }
+
+    private void submit(TeamBuildingStatus status) {
+        if (status == TeamBuildingStatus.APPLY) {
+            service.apply(principal, new ProjectAppliesRequest(List.of(
+                new ProjectAppliesRequest.ApplyRequest(10L, "backend", "comment"))), 2);
+        } else {
+            service.setPreference(principal, new RecruitmentDto(10L, List.of(
+                new RecruitmentDto.RecruitmentInfo(1, "backend", List.of()))), 2);
+        }
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = TeamBuildingStatus.class, names = {"APPLY", "RECRUIT"})
+    void closingWaitsUntilSubmissionCommits(TeamBuildingStatus status) throws Exception {
+        initialize(status);
+        CountDownLatch saved = new CountDownLatch(1);
+        if (status == TeamBuildingStatus.APPLY) {
+            when(applies.save(any())).thenAnswer(call -> {
+                saved.countDown(); await(release); return call.getArgument(0);
+            });
+        } else {
+            when(recruits.save(any())).thenAnswer(call -> {
+                saved.countDown(); await(release); return call.getArgument(0);
+            });
+        }
+        Future<?> submission = executor.submit(() -> submit(status));
+        await(saved);
+        CountDownLatch closing = new CountDownLatch(1);
+        Future<?> close = executor.submit(() -> transaction.executeWithoutResult(ignored -> {
+            closing.countDown();
+            metas.findBySemesterForUpdate(generateSemester()).orElseThrow()
+                .changeStatus(TeamBuildingStatus.CLOSED);
+        }));
+        await(closing);
+        assertThatThrownBy(() -> close.get(300, TimeUnit.MILLISECONDS))
+            .isInstanceOf(TimeoutException.class);
+        release.countDown();
+        submission.get(10, TimeUnit.SECONDS);
+        close.get(10, TimeUnit.SECONDS);
+        assertThat(metas.findBySemester(generateSemester()).orElseThrow().getStatus())
+            .isEqualTo(TeamBuildingStatus.CLOSED);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = TeamBuildingStatus.class, names = {"APPLY", "RECRUIT"})
+    void submissionWaitsForClosingThenRejectsWithoutWriting(TeamBuildingStatus status) throws Exception {
+        initialize(status);
+        CountDownLatch closed = new CountDownLatch(1);
+        Future<?> close = executor.submit(() -> transaction.executeWithoutResult(ignored -> {
+            metas.findBySemesterForUpdate(generateSemester()).orElseThrow()
+                .changeStatus(TeamBuildingStatus.CLOSED);
+            entityManager.flush();
+            closed.countDown();
+            await(release);
+        }));
+        await(closed);
+        CountDownLatch submitting = new CountDownLatch(1);
+        Future<?> submission = executor.submit(() -> {
+            submitting.countDown(); submit(status);
+        });
+        await(submitting);
+        assertThatThrownBy(() -> submission.get(300, TimeUnit.MILLISECONDS))
+            .isInstanceOf(TimeoutException.class);
+        release.countDown();
+        close.get(10, TimeUnit.SECONDS);
+        assertThatThrownBy(() -> submission.get(10, TimeUnit.SECONDS))
+            .isInstanceOf(ExecutionException.class).hasCauseInstanceOf(ConflictException.class);
+        verifyNoInteractions(users, projects, applies, recruits, wishes);
+    }
+}

--- a/server/src/test/java/wap/web2/server/teambuild/service/TeamBuildingResultServiceTest.java
+++ b/server/src/test/java/wap/web2/server/teambuild/service/TeamBuildingResultServiceTest.java
@@ -26,6 +26,25 @@ class TeamBuildingResultServiceTest {
     @Mock
     private ProjectApplyRepository projectApplyRepository;
 
+    @Mock private wap.web2.server.member.repository.UserRepository userRepository;
+    @Mock private wap.web2.server.project.repository.ProjectRepository projectRepository;
+    @Mock private wap.web2.server.teambuild.repository.TeamRepository teamRepository;
+
+    @Test
+    void resultsUseActualAssignedPositionWithoutRequiringAnApplicationToThatProject() {
+        User leader = user(1L, "leader");
+        User member = user(2L, "member");
+        when(projectRepository.findProjectsBySemester(anyString())).thenReturn(List.of(
+            Project.builder().projectId(10L).user(leader).build()));
+        when(teamRepository.findAllBySemester(anyString())).thenReturn(List.of(
+            wap.web2.server.teambuild.entity.Team.builder().projectId(10L).memberId(2L)
+                .position(Position.BACKEND).round(3).build()));
+        when(userRepository.findAllById(List.of(2L))).thenReturn(List.of(member));
+        var result = teamBuildingResultService.getResults();
+        assertThat(result.getResults().get(0).getMembers()).containsExactly(
+            new TeamMemberResult(2L, "member", Position.BACKEND));
+    }
+
     @InjectMocks
     private TeamBuildingResultService teamBuildingResultService;
 


### PR DESCRIPTION
<!--
1. PR 이름 컨벤션
feat: 투표 상태 관리에 필요한 api 개발

2. 라벨
작업 분야: server/client
작업 종류: feat/refactor/fix/...
    이름: 가나다/가나디/기니디/...
-->

## 📌 관련 이슈

- #600

## ✨ PR 세부 내용

- 팀원 지원서 방식 변경: 프로젝트 기준 지원서 5개 -> (프로젝트, 직무) 기준 지원서 5개
- 1차 팀빌딩: 팀장 우선순위 매기기 방식 변경: 모든 지원자 -> 지원자 4명 이상
- 2차 팀빌딩 추가: 지원자 우선순위 제한 없음
  - round를 기준으로 1차와 2차를 구분한다.
- 3차 팀빌딩 추가: 결정론적인 방법으로 분야 클러스터링, 수동으로 클러스터 수정, 랜덤으로 분야별 팀원 배치

<!-- 수정/추가한 내용을 적어주세요. -->

## 👀 확인해주세요!

#600 에 언급된 내용대로 프론트엔드 API 명세가 수정됩니다

## ⌛ 소요 시간
