### PR TITLE
fear: OAuth2 로그인 실패 리다이렉트 URL의 한글 인코딩 누락 수정

### DIFF
--- a/server/src/main/java/wap/web2/server/global/security/handler/OAuth2AuthenticationFailureHandler.java
+++ b/server/src/main/java/wap/web2/server/global/security/handler/OAuth2AuthenticationFailureHandler.java
@@ -40,6 +40,7 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
             .queryParam("code", ErrorCode.AUTH_OAUTH2_FAILURE.getCode())
             .queryParam("message", ErrorCode.AUTH_OAUTH2_FAILURE.getDefaultMessage())
             .build()
+            .encode()
             .toUriString();
 
         httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(

--- a/server/src/test/java/wap/web2/server/global/security/handler/OAuth2AuthenticationFailureHandlerTest.java
+++ b/server/src/test/java/wap/web2/server/global/security/handler/OAuth2AuthenticationFailureHandlerTest.java
@@ -1,0 +1,50 @@
+package wap.web2.server.global.security.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import jakarta.servlet.http.Cookie;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import wap.web2.server.exception.ErrorCode;
+import wap.web2.server.global.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
+
+class OAuth2AuthenticationFailureHandlerTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void redirectsWithAsciiLocationAndPreservesKoreanError(boolean hasRedirectCookie)
+        throws Exception {
+        var repository = mock(HttpCookieOAuth2AuthorizationRequestRepository.class);
+        var handler = new OAuth2AuthenticationFailureHandler(repository);
+        var request = new MockHttpServletRequest("GET", "/oauth2/callback/kakao");
+        var response = new MockHttpServletResponse();
+        String target = hasRedirectCookie ? "https://waps.im/oauth/callback" : "/";
+        if (hasRedirectCookie) {
+            request.setCookies(new Cookie("redirect_uri", target));
+        }
+
+        handler.onAuthenticationFailure(
+            request, response, new OAuth2AuthenticationException("invalid_state_parameter")
+        );
+
+        assertEquals(302, response.getStatus());
+        String location = response.getHeader("Location");
+        assertNotNull(location);
+        assertTrue(location.chars().allMatch(character -> character < 128));
+        assertTrue(location.startsWith(target + "?"));
+        String query = URLDecoder.decode(URI.create(location).getRawQuery(), StandardCharsets.UTF_8);
+        assertEquals(
+            "code=AUTH_OAUTH2_FAILURE&message=" + ErrorCode.AUTH_OAUTH2_FAILURE.getDefaultMessage(),
+            query
+        );
+        verify(repository).removeAuthorizationRequestCookies(request, response);
+    }
+}


### PR DESCRIPTION
<!--
1. PR 이름 컨벤션
feat: 투표 상태 관리에 필요한 api 개발

2. 라벨
작업 분야: server/client
작업 종류: feat/refactor/fix/...
    이름: 가나다/가나디/기니디/...
-->

## 📌 관련 이슈

- #issueNum

## ✨ PR 세부 내용
카카오 로그인 시 실패 리다이렉트 URL 인코딩이 누락된 버그를 수정했습니다.

<!-- 수정/추가한 내용을 적어주세요. -->

## 👀 확인해주세요!

## ⌛ 소요 시간
