### PR TITLE
fix: Caddy 검증 시 표준입력 소비로 배포가 조기 종료되는 문제 수정

### DIFF
--- a/.github/scripts/deploy-container.sh
+++ b/.github/scripts/deploy-container.sh
@@ -59,8 +59,10 @@ fi
 # Exported environment variables take precedence over the server's .env file.
 install -m 644 "$REMOTE_DIR/Caddyfile" "$compose_dir/Caddyfile"
 install -m 644 "$REMOTE_DIR/docker-compose.yml" "$compose_dir/docker-compose.yml"
+# Remote Bash reads this script from stdin; validation must not consume the remaining commands.
 docker compose -p "$compose_project" -f "$compose_dir/docker-compose.yml" \
-  run --rm --no-deps caddy caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+  run --rm --no-deps --interactive=false caddy \
+  caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile </dev/null
 docker compose -p "$compose_project" -f "$compose_dir/docker-compose.yml" \
   up -d --no-deps --force-recreate caddy
 


### PR DESCRIPTION
## 📌 관련 이슈

- 별도 이슈 없음

## ✨ PR 세부 내용

SSH의 `bash -se`로 스크립트를 전달할 때 Caddy 검증용 `docker compose run`이 남은 표준입력을 소비하면, `Valid configuration` 이후 실제 Caddy/앱 배포 없이 워크플로가 성공으로 종료될 수 있습니다.

검증 명령에 `--interactive=false`와 `</dev/null`을 적용해 후속 배포 명령이 계속 실행되도록 수정했습니다.

## 👀 확인해주세요!

- Bash 문법 검사, ShellCheck, actionlint, `git diff --check` 통과
- 표준입력을 소비하는 Docker 모의 명령을 사용한 `bash -se` 재현 검사: 수정 전 후속 명령 미실행, 수정 후 실행 확인
- 실제 OCI 배포는 수행하지 않았습니다. 배포 적용 후 `Deployment completed successfully.` 로그와 Caddy/앱 컨테이너 실행을 확인해야 합니다.

## ⌛ 소요 시간

- 약 5분
