### PR TITLE
fix: 서버 배포 워크플로 조기 종료 수정 반영

### DIFF
--- a/.github/scripts/deploy-container.sh
+++ b/.github/scripts/deploy-container.sh
@@ -59,8 +59,10 @@ fi
 # Exported environment variables take precedence over the server's .env file.
 install -m 644 "$REMOTE_DIR/Caddyfile" "$compose_dir/Caddyfile"
 install -m 644 "$REMOTE_DIR/docker-compose.yml" "$compose_dir/docker-compose.yml"
+# Remote Bash reads this script from stdin; validation must not consume the remaining commands.
 docker compose -p "$compose_project" -f "$compose_dir/docker-compose.yml" \
-  run --rm --no-deps caddy caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+  run --rm --no-deps --interactive=false caddy \
+  caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile </dev/null
 docker compose -p "$compose_project" -f "$compose_dir/docker-compose.yml" \
   up -d --no-deps --force-recreate caddy
 


### PR DESCRIPTION
## 📌 관련 이슈

- #633

## ✨ PR 세부 내용

Caddy 설정 검증 이후 실제 서버 배포 없이 워크플로가 성공으로 종료될 수 있는 문제를 수정합니다.

`develop`에 병합된 #633을 `main`에 반영합니다. 검증용 `docker compose run`에 `--interactive=false`와 `</dev/null`을 적용하여 SSH의 `bash -se`가 읽는 후속 배포 명령이 소비되지 않도록 했습니다. 변경 파일은 `.github/scripts/deploy-container.sh` 하나입니다.

## 👀 확인해주세요!

- #633에서 Bash 문법 검사, ShellCheck, actionlint, `git diff --check` 통과
- 표준입력을 소비하는 모의 명령으로 수정 전 후속 명령 미실행 및 수정 후 실행 확인
- #633의 PR Build Check와 자동 코드 리뷰 통과 (Client/Server Build는 변경 경로에 따라 생략)
- 이 PR이 main에 병합되면 Server Deploy 워크플로가 실행됩니다. `Deployment completed successfully.` 로그와 `caddy`, `waps-server` 실행 상태를 확인해주세요.
- 실제 OCI 배포 검증은 아직 수행하지 않았습니다.

## ⌛ 소요 시간

- #633 수정 사항의 main 반영 PR
