### PR TITLE
fix: Netlify 배포 도메인의 CORS 및 OAuth 리다이렉트 허용

### DIFF
--- a/server/src/main/java/wap/web2/server/config/WebMvcConfig.java
+++ b/server/src/main/java/wap/web2/server/config/WebMvcConfig.java
@@ -16,6 +16,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
         "https://wapst.netlify.app",
         "https://waps.im",
         "https://waps-deploy.netlify.app",
+        "https://waps-web.netlify.app",
         "http://localhost:3000",
         "http://localhost:8080"
     };

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -56,11 +56,6 @@ app:
     tokenSecret: ${JWT_SECRET_KEY}
     tokenExpirationMsec: 86400000
     refreshTokenExpirationMsec: 1209600000
-  #  cors:
-  #    allowedOrigins:
-  #      - https://wap-projects.netlify.app
-  #      - http://localhost:3000
-  #      - http://localhost:8080
   oauth2:
     authorizedRedirectUris:
       - https://waps.im/oauth2/redirect

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -66,6 +66,7 @@ app:
       - https://waps.im/oauth2/redirect
       - https://wapst.netlify.app/oauth2/redirect
       - https://waps-deploy.netlify.app/oauth2/redirect
+      - https://waps-web.netlify.app/oauth2/redirect
       - http://localhost:3000/oauth2/redirect
       - myandroidapp://oauth2/redirect
       - myiosapp://oauth2/redirect


### PR DESCRIPTION
## 📌 관련 이슈

- 없음

## ✨ PR 세부 내용

Netlify 배포 주소 `https://waps-web.netlify.app`에서 API 요청과 OAuth 로그인 후 리다이렉트를 허용합니다.

- 서버 CORS 허용 목록에 `https://waps-web.netlify.app` 추가
- OAuth2 허용 리다이렉트 목록에 `https://waps-web.netlify.app/oauth2/redirect` 추가
- application.yml의 사용하지 않는 CORS 설정 주석 제거

## 👀 확인해주세요!

- 서버 재배포 후 Netlify 사이트에서 API 요청과 카카오 로그인 동작 확인이 필요합니다.
- `git diff --check origin/develop...HEAD` 통과
- 빌드 및 통합 테스트는 실행하지 않았습니다.

## ⌛ 소요 시간

- 별도 측정하지 않음
