### PR TITLE
fix: Netlify 도메인 CORS 및 OAuth 설정 운영 반영

### DIFF
--- a/server/src/main/java/wap/web2/server/config/WebMvcConfig.java
+++ b/server/src/main/java/wap/web2/server/config/WebMvcConfig.java
@@ -16,6 +16,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
         "https://wapst.netlify.app",
         "https://waps.im",
         "https://waps-deploy.netlify.app",
+        "https://waps-web.netlify.app",
         "http://localhost:3000",
         "http://localhost:8080"
     };

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -56,11 +56,6 @@ app:
     tokenSecret: ${JWT_SECRET_KEY}
     tokenExpirationMsec: 86400000
     refreshTokenExpirationMsec: 1209600000
-  #  cors:
-  #    allowedOrigins:
-  #      - https://wap-projects.netlify.app
-  #      - http://localhost:3000
-  #      - http://localhost:8080
   oauth2:
     authorizedRedirectUris:
       - https://waps.im/oauth2/redirect

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -66,6 +66,7 @@ app:
       - https://waps.im/oauth2/redirect
       - https://wapst.netlify.app/oauth2/redirect
       - https://waps-deploy.netlify.app/oauth2/redirect
+      - https://waps-web.netlify.app/oauth2/redirect
       - http://localhost:3000/oauth2/redirect
       - myandroidapp://oauth2/redirect
       - myiosapp://oauth2/redirect


### PR DESCRIPTION
## 📌 관련 이슈

- #635

## ✨ PR 세부 내용

Netlify 배포 사이트에서 API 요청과 OAuth 로그인 후 리다이렉트가 가능하도록 develop의 변경사항을 main에 반영합니다.

- CORS 허용 주소에 `https://waps-web.netlify.app` 추가
- OAuth2 허용 리다이렉트 주소에 `https://waps-web.netlify.app/oauth2/redirect` 추가
- 사용하지 않는 CORS 설정 주석 제거

## 👀 확인해주세요!

- #635의 Server Build, PR Build Check, Code Review 통과
- 서버 배포 후 Netlify 사이트에서 API 요청과 로그인 동작 확인 필요

## ⌛ 소요 시간

- 별도 측정하지 않음
