### PR TITLE
chore: 개발 서버 Docker 구성 및 Cloudflare 환경변수 설정

### DIFF
--- a/server/cloudflare/config.yml
+++ b/server/cloudflare/config.yml
@@ -1,0 +1,16 @@
+# Docker Compose fragment; content is mounted as /etc/cloudflared/config.yml.
+configs:
+  cloudflared_config:
+    content: |
+      tunnel: waps
+      credentials-file: /run/secrets/cloudflared_credentials
+      protocol: http2
+
+      ingress:
+        - hostname: "${CLOUDFLARE_HOSTNAME}"
+          service: http://app:8080
+        - service: http_status:404
+
+secrets:
+  cloudflared_credentials:
+    environment: CLOUDFLARE_TUNNEL_CREDENTIALS

--- a/server/docker-compose.dev.yml
+++ b/server/docker-compose.dev.yml
@@ -17,7 +17,7 @@ services:
       # OAuth2
       KAKAO_REST_API_KEY: ${KAKAO_REST_API_KEY}
       KAKAO_CLIENT_SECRET: ${KAKAO_CLIENT_SECRET}
-      SERVER_URL: ${SERVER_URL:-http://localhost}
+      SERVER_URL: ${DEV_SERVER_URL:-http://localhost}
       # Azure Blob Storage
       AZURE_STORAGE_CONNECTION_STRING: ${AZURE_STORAGE_CONNECTION_STRING}
       # AWS S3

--- a/server/docker-compose.dev.yml
+++ b/server/docker-compose.dev.yml
@@ -1,0 +1,86 @@
+services:
+  app:
+    platform: linux/arm64
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: waps-server
+    environment:
+      # Database
+      DB_HOST: ${DB_HOST}
+      DB_PORT: 3306
+      DB_NAME: ${DB_NAME:-waps}
+      DB_USER: ${DB_USER:-waps}
+      DB_PASSWORD: ${DB_PASSWORD:-waps1234}
+      # JWT
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      # OAuth2
+      KAKAO_REST_API_KEY: ${KAKAO_REST_API_KEY}
+      KAKAO_CLIENT_SECRET: ${KAKAO_CLIENT_SECRET}
+      SERVER_URL: ${SERVER_URL:-http://localhost}
+      # Azure Blob Storage
+      AZURE_STORAGE_CONNECTION_STRING: ${AZURE_STORAGE_CONNECTION_STRING}
+      # AWS S3
+      AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
+      AWS_SECRET_KEY: ${AWS_SECRET_KEY}
+      AWS_S3_BUCKET_NAME: ${AWS_S3_BUCKET_NAME}
+      AWS_REGION: ${AWS_REGION:-ap-northeast-2}
+      # Oracle Object Storage
+      OCI_NAMESPACE: ${OCI_NAMESPACE}
+      OCI_BUCKET_NAME: ${OCI_BUCKET_NAME}
+      OCI_REGION: ${OCI_REGION}
+      OCI_CONFIG_PATH: /home/ubuntu/.oci/config
+      # Swagger
+      SWAGGER_SERVER_URL: ${SWAGGER_SERVER_URL:-http://localhost}
+      # Spring
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE}
+    depends_on:
+      mysql:
+        condition: service_healthy
+    networks:
+      - waps-network
+    volumes:
+      - ${HOME}/.oci:/home/ubuntu/.oci:ro
+    restart: unless-stopped
+
+  mysql:
+    image: mysql:8.0
+    container_name: waps-mysql
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-root1234}
+      MYSQL_DATABASE: ${DB_NAME:-waps}
+      MYSQL_USER: ${DB_USER:-waps}
+      MYSQL_PASSWORD: ${DB_PASSWORD:-waps1234}
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    networks:
+      - waps-network
+    restart: unless-stopped
+
+  cloudflared:
+    image: cloudflare/cloudflared:2026.8.3
+    container_name: cloudflared
+    restart: unless-stopped
+    volumes:
+      - /Users/mb/cloudflare:/etc/cloudflared:ro
+    command: tunnel --config /etc/cloudflared/config.yml run waps-dev
+    networks:
+      - waps-network
+    depends_on:
+      app:
+        condition: service_healthy
+
+networks:
+  waps-network:
+    driver: bridge
+
+volumes:
+  mysql-data:

--- a/server/docker-compose.dev.yml
+++ b/server/docker-compose.dev.yml
@@ -1,3 +1,7 @@
+include:
+  - path: ./cloudflare/config.yml
+    project_directory: .
+
 services:
   app:
     platform: linux/arm64
@@ -69,8 +73,11 @@ services:
     image: cloudflare/cloudflared:2026.8.3
     container_name: cloudflared
     restart: unless-stopped
-    volumes:
-      - /Users/mb/cloudflare:/etc/cloudflared:ro
+    secrets:
+      - cloudflared_credentials
+    configs:
+      - source: cloudflared_config
+        target: /etc/cloudflared/config.yml
     command: tunnel --config /etc/cloudflared/config.yml run waps-dev
     networks:
       - waps-network

--- a/server/src/main/java/wap/web2/server/config/WebMvcConfig.java
+++ b/server/src/main/java/wap/web2/server/config/WebMvcConfig.java
@@ -15,8 +15,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
         "https://www.waps.store",
         "https://wapst.netlify.app",
         "https://waps.im",
+        "https://dev.waps.im",
         "https://waps-deploy.netlify.app",
         "https://waps-web.netlify.app",
+        "https://waps-develop.netlify.app",
         "http://localhost:3000",
         "http://localhost:8080"
     };

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -59,9 +59,11 @@ app:
   oauth2:
     authorizedRedirectUris:
       - https://waps.im/oauth2/redirect
+      - https://dev.waps.im/oauth2/redirect
       - https://wapst.netlify.app/oauth2/redirect
       - https://waps-deploy.netlify.app/oauth2/redirect
       - https://waps-web.netlify.app/oauth2/redirect
+      - https://waps-develop.netlify.app/oauth2/redirect
       - http://localhost:3000/oauth2/redirect
       - myandroidapp://oauth2/redirect
       - myiosapp://oauth2/redirect


### PR DESCRIPTION
## 📌 관련 이슈

- 연결된 이슈 없음

## ✨ PR 세부 내용

개발 서버에서 앱, MySQL, Cloudflare Tunnel을 함께 실행하는 Docker Compose 구성을 추가합니다. 개발 도메인의 CORS 요청과 OAuth2 리다이렉트를 허용하고, 개발 Docker 환경의 카카오 로그인 서버 주소에는 `DEV_SERVER_URL`을 사용합니다.

Cloudflare 설정의 개인 PC 절대 경로 의존성을 제거합니다. `cloudflare/config.yml`을 Compose 설정 조각으로 포함하여 `CLOUDFLARE_HOSTNAME`을 치환하고, `CLOUDFLARE_TUNNEL_CREDENTIALS`에 저장한 전체 인증 JSON을 Compose secret으로 마운트합니다. 두 값은 `server/.env`에서 관리할 수 있으며, 별도의 호스트 인증 JSON 파일은 필요하지 않습니다.

## 👀 확인해주세요!

- Docker Compose 2.23.1 이상이 필요합니다.
- 개발 환경에 `CLOUDFLARE_HOSTNAME`, `CLOUDFLARE_TUNNEL_CREDENTIALS`, `DEV_SERVER_URL`을 설정해주세요. 인증 정보는 Git에 포함하지 않습니다.
- `docker compose -f server/docker-compose.dev.yml config --quiet` 및 `git diff --check`를 통과했습니다.
- 인증 정보의 `.env` 로딩과 secret 마운트 설정을 검증했습니다. 실제 컨테이너 실행, 터널 연결 및 개발 도메인의 로그인 동작은 검증하지 않았습니다.

## ⌛ 소요 시간

- 별도 기록 없음
