### PR TITLE
fix: Cloudflare 터널 실행 이름을 waps로 수정

### DIFF
--- a/server/docker-compose.dev.yml
+++ b/server/docker-compose.dev.yml
@@ -78,7 +78,7 @@ services:
     configs:
       - source: cloudflared_config
         target: /etc/cloudflared/config.yml
-    command: tunnel --config /etc/cloudflared/config.yml run waps-dev
+    command: tunnel --config /etc/cloudflared/config.yml run waps
     networks:
       - waps-network
     depends_on:


### PR DESCRIPTION
## 📌 관련 이슈

- 연결된 이슈 없음

## ✨ PR 세부 내용

개발용 Docker Compose의 Cloudflare Tunnel 실행 인자를 `waps-dev`에서 실제 터널 이름인 `waps`로 수정합니다. 실행 명령과 `cloudflare/config.yml`의 `tunnel: waps`가 동일한 이름을 사용하도록 맞춥니다.

## 👀 확인해주세요!

- `docker compose -f server/docker-compose.dev.yml config --quiet` 및 `git diff --check`를 통과했습니다.
- 실제 컨테이너 실행과 터널 연결은 검증하지 않았습니다.

## ⌛ 소요 시간

- 별도 기록 없음
