### PR TITLE
feat: 개발 로그인에서 테스트 계정 번호 지정 지원

### DIFF
--- a/client/src/api/auth.js
+++ b/client/src/api/auth.js
@@ -3,10 +3,10 @@ import axios from "axios";
 
 export const authApi = {
   // 기존 쿠키의 만료된 토큰을 보내지 않고 새 개발 세션을 발급받는다.
-  loginDev: async (sessionId) => {
+  loginDev: async (sessionId, accountNumber) => {
     const response = await axios.post(
       `${process.env.REACT_APP_API_BASE_URL || "http://localhost:8080"}/auth/login-dev`,
-      { sessionId },
+      { sessionId, accountNumber },
       { timeout: 30000 },
     );
     return response.data;

--- a/client/src/pages/LoginDev.js
+++ b/client/src/pages/LoginDev.js
@@ -1,11 +1,13 @@
 import { useEffect, useRef, useState } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate, useSearchParams } from "react-router-dom";
 import { getDevSessionId, saveDevSession } from "../utils/authStorage";
 import { authApi } from "../api/auth";
 import LoadingPage from "../components/LoadingPage";
 import { isDevLoginEnabled } from "../utils/devLogin";
 
 export default function LoginDev() {
+  const [searchParams] = useSearchParams();
+  const requestedId = searchParams.get("id");
   const enabled = isDevLoginEnabled();
   const started = useRef(false);
   const [error, setError] = useState(false);
@@ -14,7 +16,13 @@ export default function LoginDev() {
     if (!enabled || started.current) return;
     started.current = true;
 
-    Promise.resolve().then(() => authApi.loginDev(getDevSessionId())).then((session) => {
+    if (requestedId !== null && (!/^[0-9]+$/.test(requestedId) || Number(requestedId) < 1 || Number(requestedId) > 100)) {
+      setError("테스트 계정 번호는 1~100 사이의 정수여야 합니다.");
+      return;
+    }
+
+    Promise.resolve().then(() => authApi.loginDev(getDevSessionId(),
+      requestedId === null ? undefined : Number(requestedId))).then((session) => {
       if (!session.accessToken || !session.userName || !session.expiresAt) throw new Error("Invalid login response");
       saveDevSession(session);
       // Reload shared layouts so the assigned account name is immediately reflected.
@@ -22,7 +30,7 @@ export default function LoginDev() {
     }).catch((failure) => setError(failure.response?.status === 409
       ? failure.response.data?.message || "테스트 계정이 모두 사용 중입니다. 잠시 후 다시 시도해주세요."
       : "개발 로그인에 실패했습니다. 잠시 후 다시 시도해주세요."));
-  }, [enabled]);
+  }, [enabled, requestedId]);
 
   if (!enabled) return <Navigate to="/login" replace />;
   if (error) return (

--- a/client/src/pages/LoginDev.test.js
+++ b/client/src/pages/LoginDev.test.js
@@ -9,8 +9,8 @@ jest.mock("../utils/authStorage", () => ({ getDevSessionId: jest.fn(() => "sessi
 jest.mock("../api/auth", () => ({ authApi: { loginDev: jest.fn() } }));
 const originalLocation = window.location;
 
-function openPage() {
-  render(<StrictMode><MemoryRouter initialEntries={["/login-dev"]}><Routes>
+function openPage(path = "/login-dev") {
+  render(<StrictMode><MemoryRouter initialEntries={[path]}><Routes>
     <Route path="/login-dev" element={<LoginDev />} />
     <Route path="/login" element={<p>Kakao login</p>} />
   </Routes></MemoryRouter></StrictMode>);
@@ -44,7 +44,7 @@ test("automatically allocates once even in StrictMode and saves a tab session", 
   openPage();
   await waitFor(() => expect(window.location.replace).toHaveBeenCalledWith("/ProjectPage"));
   expect(authApi.loginDev).toHaveBeenCalledTimes(1);
-  expect(authApi.loginDev).toHaveBeenCalledWith("session-id");
+  expect(authApi.loginDev).toHaveBeenCalledWith("session-id", undefined);
   expect(saveDevSession).toHaveBeenCalledWith(session);
 });
 
@@ -55,5 +55,31 @@ test.each([
   authApi.loginDev.mockRejectedValue(failure);
   openPage();
   expect((await screen.findByRole("alert")).textContent).toContain(message);
+  expect(saveDevSession).not.toHaveBeenCalled();
+});
+
+
+test.each([1, 100])("logs in with requested test account %s once", async (id) => {
+  const session = { accessToken: "signed-token", userName: `테스트 사용자 ${id}`, expiresAt: "2099-01-01T00:00:00Z" };
+  authApi.loginDev.mockResolvedValue(session);
+  openPage(`/login-dev?id=${id}`);
+  await waitFor(() => expect(window.location.replace).toHaveBeenCalledWith("/ProjectPage"));
+  expect(authApi.loginDev).toHaveBeenCalledTimes(1);
+  expect(authApi.loginDev).toHaveBeenCalledWith("session-id", id);
+  expect(saveDevSession).toHaveBeenCalledWith(session);
+});
+
+test.each(["", "0", "101", "-1", "1.5", "abc", "1e1"])("rejects invalid id '%s' without allocating an account", async (id) => {
+  openPage(`/login-dev?id=${id}`);
+  expect((await screen.findByRole("alert")).textContent).toContain("1~100");
+  expect(authApi.loginDev).not.toHaveBeenCalled();
+  expect(saveDevSession).not.toHaveBeenCalled();
+});
+
+test("shows the requested account conflict without redirecting", async () => {
+  authApi.loginDev.mockRejectedValue({ response: { status: 409, data: { message: "테스트 계정 1번이 사용 중입니다." } } });
+  openPage("/login-dev?id=1");
+  expect((await screen.findByRole("alert")).textContent).toContain("1번이 사용 중");
+  expect(window.location.replace).not.toHaveBeenCalled();
   expect(saveDevSession).not.toHaveBeenCalled();
 });

--- a/server/src/main/java/wap/web2/server/auth/DevLoginController.java
+++ b/server/src/main/java/wap/web2/server/auth/DevLoginController.java
@@ -2,6 +2,8 @@ package wap.web2.server.auth;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
@@ -17,8 +19,8 @@ public class DevLoginController {
     private final DevLoginService service;
 
     @PostMapping("/auth/login-dev")
-    public DevLoginService.DevLoginResponse login(@Valid @RequestBody SessionRequest request) {
-        return service.login(request.sessionId());
+    public DevLoginService.DevLoginResponse login(@Valid @RequestBody LoginRequest request) {
+        return service.login(request.sessionId(), request.accountNumber());
     }
 
     @PostMapping("/auth/login-dev/release")
@@ -26,6 +28,8 @@ public class DevLoginController {
         service.release(request.sessionId());
         return ResponseEntity.noContent().build();
     }
+
+    public record LoginRequest(@NotNull UUID sessionId, @Min(1) @Max(100) Integer accountNumber) {}
 
     public record SessionRequest(@NotNull UUID sessionId) {}
 }

--- a/server/src/main/java/wap/web2/server/auth/DevLoginService.java
+++ b/server/src/main/java/wap/web2/server/auth/DevLoginService.java
@@ -27,14 +27,25 @@ public class DevLoginService {
 
     @Transactional
     public DevLoginResponse login(UUID sessionId) {
+        return login(sessionId, null);
+    }
+
+    @Transactional
+    public DevLoginResponse login(UUID sessionId, Integer accountNumber) {
         var pool = slots.findAllForUpdate();
         var now = Instant.now();
         String session = sessionId.toString();
-        var slot = pool.stream()
+        var slot = accountNumber == null ? pool.stream()
             .filter(s -> session.equals(s.getSessionId()) && !s.isAvailable(now))
             .findFirst()
             .orElseGet(() -> pool.stream().filter(s -> s.isAvailable(now)).findFirst()
-                .orElseThrow(() -> new ConflictException("테스트 계정 100개가 모두 사용 중입니다. 잠시 후 다시 시도해주세요.")));
+                .orElseThrow(() -> new ConflictException("테스트 계정 100개가 모두 사용 중입니다. 잠시 후 다시 시도해주세요.")))
+            : pool.stream().filter(s -> s.getSlotNumber().equals(accountNumber)).findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("테스트 계정 번호는 1~100이어야 합니다."));
+
+        if (!slot.isAvailable(now) && !session.equals(slot.getSessionId())) {
+            throw new ConflictException("테스트 계정 " + accountNumber + "번이 사용 중입니다. 다른 계정을 선택해주세요.");
+        }
 
         // Retrying the same request must not consume another account.
         if (slot.isAvailable(now)) {

--- a/server/src/test/java/wap/web2/server/auth/DevLoginControllerTest.java
+++ b/server/src/test/java/wap/web2/server/auth/DevLoginControllerTest.java
@@ -31,6 +31,24 @@ class DevLoginControllerTest {
     }
 
     @Test
+    void acceptsAccountNumberAndRejectsOutOfRangeNumbers() throws Exception {
+        var mvc = MockMvcBuilders.standaloneSetup(new DevLoginController(service)).build();
+        UUID session = UUID.randomUUID();
+        for (int number : new int[] {0, -1, 101}) {
+            mvc.perform(post("/auth/login-dev").contentType("application/json")
+                .content("{\"sessionId\":\"" + session + "\",\"accountNumber\":" + number + "}"))
+                .andExpect(status().isBadRequest());
+        }
+        verifyNoInteractions(service);
+        for (int number : new int[] {1, 100}) {
+            mvc.perform(post("/auth/login-dev").contentType("application/json")
+                .content("{\"sessionId\":\"" + session + "\",\"accountNumber\":" + number + "}"))
+                .andExpect(status().isOk());
+            verify(service).login(session, number);
+        }
+    }
+
+    @Test
     void requiresValidSessionIdentifier() throws Exception {
         var mvc = MockMvcBuilders.standaloneSetup(new DevLoginController(service)).build();
         for (String body : new String[] {"{}", "{\"sessionId\":\"invalid\"}"}) {
@@ -41,6 +59,6 @@ class DevLoginControllerTest {
         UUID id = UUID.randomUUID();
         mvc.perform(post("/auth/login-dev").contentType("application/json")
             .content("{\"sessionId\":\"" + id + "\"}")).andExpect(status().isOk());
-        verify(service).login(id);
+        verify(service).login(id, null);
     }
 }

--- a/server/src/test/java/wap/web2/server/auth/DevLoginServiceTest.java
+++ b/server/src/test/java/wap/web2/server/auth/DevLoginServiceTest.java
@@ -1,0 +1,81 @@
+package wap.web2.server.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import wap.web2.server.auth.domain.DevLoginSlot;
+import wap.web2.server.exception.ConflictException;
+import wap.web2.server.global.security.jwt.TokenProvider;
+import wap.web2.server.member.entity.Role;
+import wap.web2.server.member.entity.User;
+import wap.web2.server.member.repository.UserRepository;
+
+class DevLoginServiceTest {
+    private final DevLoginSlotRepository slots = mock(DevLoginSlotRepository.class);
+    private final UserRepository users = mock(UserRepository.class);
+    private final TokenProvider tokens = mock(TokenProvider.class);
+    private final DevLoginService service = new DevLoginService(slots, users, tokens);
+    private final DevLoginSlot first = new DevLoginSlot(1);
+    private final DevLoginSlot second = new DevLoginSlot(2);
+    private final UUID session = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        when(slots.findAllForUpdate()).thenReturn(List.of(first, second));
+        for (var slot : List.of(first, second)) {
+            var user = new User();
+            user.setId(slot.getSlotNumber().longValue());
+            user.setName("테스트 사용자 " + slot.getSlotNumber());
+            user.setRole(Role.ROLE_MEMBER);
+            slot.setUserId(user.getId());
+            when(users.findById(user.getId())).thenReturn(Optional.of(user));
+        }
+    }
+
+    @Test
+    void selectsRequestedAccountAndReusesSessionOnRetry() {
+        assertEquals(2, service.login(session, 2).accountNumber());
+        String tokenId = second.getTokenId();
+        Instant expiry = second.getExpiresAt();
+        assertEquals(2, service.login(session, 2).accountNumber());
+        assertEquals(tokenId, second.getTokenId());
+        assertEquals(expiry, second.getExpiresAt());
+        assertNull(first.getSessionId());
+        assertEquals(2, service.login(session).accountNumber());
+    }
+
+    @Test
+    void switchingAccountsReleasesPreviousSlot() {
+        assertEquals(1, service.login(session).accountNumber());
+        assertEquals(2, service.login(session, 2).accountNumber());
+        assertNull(first.getSessionId());
+        assertNull(first.getTokenId());
+        assertEquals(session.toString(), second.getSessionId());
+    }
+
+    @Test
+    void occupiedAccountDoesNotStealOrReleaseExistingSession() {
+        service.login(session, 1);
+        UUID other = UUID.randomUUID();
+        service.login(other, 2);
+        assertThrows(ConflictException.class, () -> service.login(session, 2));
+        assertEquals(session.toString(), first.getSessionId());
+        assertEquals(other.toString(), second.getSessionId());
+    }
+
+    @Test
+    void reclaimsExpiredRequestedAccount() {
+        service.login(UUID.randomUUID(), 2);
+        String oldTokenId = second.getTokenId();
+        second.setExpiresAt(Instant.now().minusSeconds(1));
+        assertEquals(2, service.login(session, 2).accountNumber());
+        assertEquals(session.toString(), second.getSessionId());
+        assertNotEquals(oldTokenId, second.getTokenId());
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

- 별도 연결 이슈 없음

## ✨ PR 세부 내용

`/login-dev?id=1`로 접속하면 테스트 사용자 1로 로그인할 수 있습니다. `id`를 생략한 `/login-dev`는 기존 자동 배정을 유지합니다.

- 서버 로그인 요청에 선택적인 `accountNumber`(1~100)를 추가했습니다.
- 같은 세션의 재시도는 기존 배정을 재사용하고, 다른 계정으로 전환하면 이전 배정을 해제합니다.
- 다른 세션이 사용 중인 계정은 409 오류를 반환하며, 클라이언트에서 안내 문구를 표시합니다.
- URL의 잘못된 계정 번호는 로그인 요청 전에 검증합니다.

서버 기능과 테스트, 클라이언트 연결과 테스트를 각각 커밋으로 분리했습니다.

## 👀 확인해주세요!

- `/login-dev`: 자동 배정
- `/login-dev?id=1` 및 `?id=100`: 지정한 테스트 계정 로그인
- 잘못된 번호 및 사용 중인 계정: 오류 표시
- 기존 개발 환경 전용 활성화 조건 유지

검증 결과:
- 서버 개발 로그인 컨트롤러/서비스 테스트 8개 통과
- 클라이언트 로그인 페이지/인증 저장소/개발 로그인 활성화 테스트 21개 통과
- DB 동시성 테스트 1개는 `DEV_LOGIN_TEST_URL` 미설정으로 생략
- `git diff --check` 통과

## ⌛ 소요 시간

- 별도 기록 없음
