### PR TITLE
style: 팀빌딩 지원서 제목 및 주요 직무 카드 디자인 수정

### DIFF
--- a/client/src/assets/TeamBuildApply.module.css
+++ b/client/src/assets/TeamBuildApply.module.css
@@ -200,6 +200,42 @@
   display: block;
 }
 
+.primaryPositionCard {
+  margin-top: 24px;
+  padding: 20px 24px;
+  border-radius: 28px;
+  background: #252a2e;
+}
+
+.primaryPositionHeader h2 {
+  margin: 0 0 4px;
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.primaryPositionHeader p {
+  margin: 0 0 14px;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.formGroup.primaryPositionSelect {
+  margin-bottom: 0;
+}
+
+.formGroup.primaryPositionSelect select {
+  border-radius: 999px;
+  background-color: rgba(255, 255, 255, 0.15);
+  font-weight: 600;
+}
+
+.primaryPositionSelect select option {
+  background: #252a2e;
+  color: #f8f8f8;
+}
+
 .myApplyTitle {
   display: block;
 }

--- a/client/src/pages/TeamBuildApplyPage.js
+++ b/client/src/pages/TeamBuildApplyPage.js
@@ -360,13 +360,11 @@ function TeamBuildApplyPage({ round = 1 }) {
 
         <div className={styles.hero}>
           <div className={styles.heroTitle}>
-            {isSecondRound ? "TEAM BUILDING_2ND" : "1차 팀빌딩"}
+            TEAM BUILDING_{isSecondRound ? "2ND" : "1ST"}
           </div>
-          {isSecondRound && (
-            <div className={styles.heroSubtitle}>
-              함께할 팀을 찾고, 원하는 프로젝트에 도전해보세요
-            </div>
-          )}
+          <div className={styles.heroSubtitle}>
+            함께할 팀을 찾고, 원하는 프로젝트에 도전해보세요
+          </div>
         </div>
 
         <div


### PR DESCRIPTION
## 📌 관련 이슈

- 연결된 이슈 없음

## ✨ PR 세부 내용

- 1차 팀빌딩 지원서 제목을 `TEAM BUILDING_1ST`로 변경하고, 2차와 동일한 안내 부제목을 표시합니다.
- 스타일이 없던 주요 직무 영역에 짙은 배경과 둥근 모서리, 내부 여백을 적용하여 제목·안내문·선택창을 하나의 카드로 묶습니다.
- 직무 선택창에 밝은 반투명 배경과 둥근 테두리를 적용하고, 옵션 목록의 배경과 글자색을 지정합니다.

## 👀 확인해주세요!

- 1차 지원서의 제목·부제목과 주요 직무 카드 표시를 확인해주세요.
- 검증: `npm test -- --watchAll=false --runInBand --runTestsByPath src/pages/TeamBuildApplyPage.test.js` — 14개 테스트 통과.
- `git diff --check` 통과.

## ⌛ 소요 시간

- 별도 기록 없음
