### PR TITLE
feat: 관리자의 타인 게시물 수정 및 삭제 허용

### DIFF
--- a/client/src/components/ProjectDelete/ProjectDelete.js
+++ b/client/src/components/ProjectDelete/ProjectDelete.js
@@ -8,9 +8,8 @@ const ProjectDelete = () => {
   const { projectId } = useParams(); // URL에서 projectId 가져오기
   const navigate = useNavigate();
   const token = Cookies.get("authToken"); // 로그인한 사용자 토큰 가져오기
-  const userId = Cookies.get("userId"); // 로그인한 사용자 ID 가져오기
   const [project, setProject] = useState(null); // 프로젝트 데이터
-  const [isOwner, setIsOwner] = useState(false); // 소유자인지 확인
+  const [canManage, setCanManage] = useState(false);
   const [isLoggedIn] = useState(!!token); // 로그인 여부 확인
 
   // API URL
@@ -24,10 +23,7 @@ const ProjectDelete = () => {
 
         setProject(data); // 프로젝트 데이터 설정
 
-        // 로그인한 사용자와 작성자 비교
-        if (token && data.ownerId === parseInt(userId)) {
-          setIsOwner(true);
-        }
+        setCanManage(data.canManage === true);
       } catch (error) {
         console.error("프로젝트 정보 가져오기 실패:", error);
         alert("프로젝트 정보를 불러오는 데 실패했습니다.");
@@ -36,7 +32,7 @@ const ProjectDelete = () => {
     };
 
     fetchProjectDetails();
-  }, [apiUrl, token, userId, navigate, projectId]);
+  }, [apiUrl, token, navigate, projectId]);
 
   // 프로젝트 삭제 요청
   const handleDelete = async () => {
@@ -45,14 +41,9 @@ const ProjectDelete = () => {
     }
 
     try {
-      const data = await projectApi.deleteProject(projectId);
-
-      if (data.status === 204) {
-        alert("프로젝트가 성공적으로 삭제되었습니다.");
-        navigate("/"); // 삭제 후 메인 페이지로 이동
-      } else {
-        alert("프로젝트 삭제에 실패했습니다.");
-      }
+      await projectApi.deleteProject(projectId);
+      alert("프로젝트가 성공적으로 삭제되었습니다.");
+      navigate("/"); // 삭제 후 메인 페이지로 이동
     } catch (error) {
       console.error("프로젝트 삭제 중 오류 발생:", error);
       alert("프로젝트 삭제에 실패했습니다. 다시 시도해주세요.");
@@ -69,7 +60,7 @@ const ProjectDelete = () => {
       <h1>{project.title}</h1>
       <p>{project.content}</p>
       <p>작성자: {project.ownerName}</p>
-      {isLoggedIn && isOwner ? (
+      {isLoggedIn && canManage ? (
         <button
           onClick={handleDelete}
           style={{

--- a/client/src/components/ProjectDetail/ProjectDetailForm.js
+++ b/client/src/components/ProjectDetail/ProjectDetailForm.js
@@ -26,7 +26,7 @@ const ProjectDetailForm = () => {
   const navigate = useNavigate();
 
   const token = Cookies.get("authToken"); // 로그인한 사용자 토큰
-  const [isOwner, setIsOwner] = useState(false); // 작성자인지 확인
+  const [canManage, setCanManage] = useState(false);
   const [projectData, setProjectData] = useState(null); // 프로젝트 데이터
   const [isDataLoaded, setIsDataLoaded] = useState(false); // 데이터 로딩 완료 여부
 
@@ -37,8 +37,8 @@ const ProjectDetailForm = () => {
         setProjectData(data);
         console.log("API 응답 데이터:", data);
 
-        // 작성자인지 여부 확인
-        setIsOwner(data.isOwner === true);
+        // 서버가 판단한 게시물 수정·삭제 권한
+        setCanManage(data.canManage === true);
 
         // 일정 시간 후 데이터 렌더링을 완료하도록 설정
         new Promise((resolve) => setTimeout(resolve, 400)).then(() => {
@@ -182,7 +182,7 @@ const ProjectDetailForm = () => {
       </div>
 
       <div className={styles.buttons}>
-        {isOwner && token && (
+        {canManage && token && (
           <>
             <button onClick={handleDelete} className={styles.delete_button}>
               삭제하기

--- a/client/src/components/ProjectDetail/ProjectDetailForm.test.js
+++ b/client/src/components/ProjectDetail/ProjectDetailForm.test.js
@@ -1,0 +1,117 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { projectApi } from "../../api/project";
+import Cookies from "../../utils/authStorage";
+import ProjectDetailForm from "./ProjectDetailForm";
+import ProjectDelete from "../ProjectDelete/ProjectDelete";
+
+jest.mock("../../api/project", () => ({
+  projectApi: {
+    getProjectDetail: jest.fn(),
+    getprojectUpdatePage: jest.fn(),
+    deleteProject: jest.fn(),
+  },
+}));
+jest.mock("../../utils/authStorage", () => ({ get: jest.fn() }));
+jest.mock("./Comments/Comments", () => () => null);
+jest.mock("./Comments/CommentsList", () => () => null);
+jest.mock("../LoadingPage", () => () => <p>Loading</p>);
+
+function openPage(Component) {
+  render(
+    <MemoryRouter initialEntries={["/project/10"]}>
+      <Routes>
+        <Route path="/project/:projectId" element={<Component />} />
+        <Route path="/project/edit/:projectId" element={<p>Edit page</p>} />
+        <Route path="/" element={<p>Home page</p>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Cookies.get.mockReturnValue("token");
+  jest.spyOn(window, "confirm").mockReturnValue(true);
+  jest.spyOn(window, "alert").mockImplementation(() => {});
+  projectApi.getProjectDetail.mockResolvedValue({
+    title: "Project title",
+    isOwner: false,
+    canManage: true,
+  });
+  projectApi.getprojectUpdatePage.mockResolvedValue({});
+  projectApi.deleteProject.mockResolvedValue(undefined);
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+describe.each([
+  ["상세 화면", ProjectDetailForm],
+  ["삭제 화면", ProjectDelete],
+])("%s", (_, Component) => {
+  test.each([true, false])(
+    "작성자 여부가 %s여도 관리 권한이 있으면 삭제할 수 있다",
+    async (isOwner) => {
+      projectApi.getProjectDetail.mockResolvedValue({
+        title: "Project title",
+        isOwner,
+        canManage: true,
+      });
+      openPage(Component);
+      fireEvent.click(await screen.findByRole("button", { name: "삭제하기" }));
+      await screen.findByText("Home page");
+      expect(projectApi.deleteProject).toHaveBeenCalledWith("10");
+      expect(window.alert).toHaveBeenCalledWith(
+        "프로젝트가 성공적으로 삭제되었습니다.",
+      );
+    },
+  );
+
+  test.each([
+    ["token", false],
+    ["token", undefined],
+    [undefined, true],
+  ])(
+    "인증 또는 관리 권한이 없으면 버튼을 숨긴다 (%s, %s)",
+    async (token, canManage) => {
+      Cookies.get.mockReturnValue(token);
+      projectApi.getProjectDetail.mockResolvedValue({
+        title: "Project title",
+        isOwner: false,
+        canManage,
+      });
+      openPage(Component);
+      await screen.findByText("Project title");
+      expect(screen.queryByRole("button", { name: "삭제하기" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "수정하기" })).toBeNull();
+      expect(projectApi.deleteProject).not.toHaveBeenCalled();
+    },
+  );
+
+  test("삭제 확인을 취소하면 요청하지 않는다", async () => {
+    window.confirm.mockReturnValue(false);
+    openPage(Component);
+    fireEvent.click(await screen.findByRole("button", { name: "삭제하기" }));
+    expect(projectApi.deleteProject).not.toHaveBeenCalled();
+  });
+});
+
+test("관리자는 타인의 게시물 수정 화면으로 이동할 수 있다", async () => {
+  openPage(ProjectDetailForm);
+  fireEvent.click(await screen.findByRole("button", { name: "수정하기" }));
+  await screen.findByText("Edit page");
+  expect(projectApi.getprojectUpdatePage).toHaveBeenCalledWith("10");
+});
+
+test("버튼 표시 후 서버가 수정 권한을 거절하면 이동하지 않는다", async () => {
+  projectApi.getprojectUpdatePage.mockRejectedValue({
+    response: { status: 403 },
+  });
+  openPage(ProjectDetailForm);
+  fireEvent.click(await screen.findByRole("button", { name: "수정하기" }));
+  await waitFor(() =>
+    expect(window.alert).toHaveBeenCalledWith("수정 권한이 없습니다."),
+  );
+  expect(screen.queryByText("Edit page")).toBeNull();
+});

--- a/server/src/main/java/wap/web2/server/project/dto/response/ProjectDetailsResponse.java
+++ b/server/src/main/java/wap/web2/server/project/dto/response/ProjectDetailsResponse.java
@@ -28,6 +28,7 @@ public class ProjectDetailsResponse {
     private List<ImageDto> images;
     private List<CommentDto> comments;
     private Boolean isOwner;
+    private Boolean canManage;
 
     public static ProjectDetailsResponse from(Project project) {
         List<TeamMemberDto> teamMembers = project
@@ -56,7 +57,13 @@ public class ProjectDetailsResponse {
             .images(images)
             .comments(comments)
             .isOwner(false)
+            .canManage(false)
             .build();
+    }
+
+    public ProjectDetailsResponse changeCanManage(boolean canManage) {
+        this.canManage = canManage;
+        return this;
     }
 
     public ProjectDetailsResponse changeIsOwner(boolean isOwner) {

--- a/server/src/main/java/wap/web2/server/project/service/ProjectService.java
+++ b/server/src/main/java/wap/web2/server/project/service/ProjectService.java
@@ -20,6 +20,7 @@ import wap.web2.server.exception.ForbiddenException;
 import wap.web2.server.exception.ProjectPasswordInvalidException;
 import wap.web2.server.exception.ResourceNotFoundException;
 import wap.web2.server.global.security.UserPrincipal;
+import wap.web2.server.member.entity.Role;
 import wap.web2.server.member.entity.User;
 import wap.web2.server.member.repository.UserRepository;
 import wap.web2.server.project.dto.request.ProjectRequest;
@@ -120,16 +121,12 @@ public class ProjectService {
     public ProjectDetailsResponse getProjectDetails(Long projectId, UserPrincipal userPrincipal) {
         Project project = findProject(projectId);
 
-        // response는 isOwner 플랙그가 false인 채로 생성된다.
         ProjectDetailsResponse projectDetailsResponse = ProjectDetailsResponse.from(project);
 
         if (userPrincipal != null) {
             User user = findUser(userPrincipal.getId());
-
-            if (project.isOwner(user)) {
-                // 로그인한 사용자이고, 프로젝트의 주인이면 isOwner 플래그를 true로 바꾸고 리턴한다.
-                return projectDetailsResponse.changeIsOwner(true);
-            }
+            projectDetailsResponse.changeIsOwner(project.isOwner(user));
+            projectDetailsResponse.changeCanManage(canManage(project, user));
         }
 
         return projectDetailsResponse;
@@ -153,11 +150,13 @@ public class ProjectService {
         );
         Project project = findProject(projectId);
 
-        if (!project.isOwner(user)) {
+        if (!canManage(project, user)) {
             throw new ForbiddenException("프로젝트 수정 권한이 없습니다.");
         }
 
-        return ProjectDetailsResponse.from(project);
+        return ProjectDetailsResponse.from(project)
+            .changeIsOwner(project.isOwner(user))
+            .changeCanManage(true);
     }
 
     @CacheEvict(value = "projectList", allEntries = true)
@@ -171,7 +170,7 @@ public class ProjectService {
         User user = findUser(userPrincipal.getId());
         Project project = findProject(projectId);
 
-        if (!project.isOwner(user)) {
+        if (!canManage(project, user)) {
             throw new ForbiddenException("프로젝트 수정 권한이 없습니다.");
         }
 
@@ -230,7 +229,7 @@ public class ProjectService {
         User user = findUser(userPrincipal.getId());
         Project project = findProject(projectId);
 
-        if (!project.isOwner(user)) {
+        if (!canManage(project, user)) {
             throw new ForbiddenException("프로젝트 삭제 권한이 없습니다.");
         }
         projectRepository.delete(project);
@@ -244,6 +243,10 @@ public class ProjectService {
             .findProjectsBySemester(generateSemester())
             .stream()
             .anyMatch(project -> project.isOwner(user));
+    }
+
+    private boolean canManage(Project project, User user) {
+        return user.getRole() == Role.ROLE_ADMIN || project.isOwner(user);
     }
 
     private User findUser(Long userId) {

--- a/server/src/test/java/wap/web2/server/project/service/ProjectServiceTest.java
+++ b/server/src/test/java/wap/web2/server/project/service/ProjectServiceTest.java
@@ -1,6 +1,8 @@
 package wap.web2.server.project.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -12,12 +14,17 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
+import wap.web2.server.exception.ForbiddenException;
+import wap.web2.server.exception.ProjectPasswordInvalidException;
 import wap.web2.server.global.security.UserPrincipal;
+import wap.web2.server.member.entity.Role;
 import wap.web2.server.member.entity.User;
 import wap.web2.server.member.repository.UserRepository;
 import wap.web2.server.project.dto.TeamMemberDto;
@@ -160,6 +167,78 @@ class ProjectServiceTest {
         // then
         assertThat(project.getImages()).isEmpty();
         verify(objectStorageService, never()).deleteImage(legacyS3Url);
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "1, ROLE_MEMBER", "2, ROLE_ADMIN" })
+    void 작성자와_관리자는_수정_조회와_수정_삭제가_가능하다(Long userId, Role role) throws Exception {
+        User owner = owner();
+        User user = new User();
+        user.setId(userId);
+        user.setRole(role);
+        UserPrincipal principal = principal(userId);
+        Project project = project(owner);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(projectRepository.findById(10L)).thenReturn(Optional.of(project));
+
+        var details = projectService.getProjectDetails(10L, principal);
+        assertThat(details.getIsOwner()).isEqualTo(userId.equals(owner.getId()));
+        assertThat(details.getCanManage()).isTrue();
+        var updateDetails = projectService.getProjectDetailsForUpdate(10L, principal);
+        assertThat(updateDetails.getProjectId()).isEqualTo(10L);
+        assertThat(updateDetails.getCanManage()).isTrue();
+        assertThat(updateDetails.getIsOwner()).isEqualTo(userId.equals(owner.getId()));
+        projectService.update(10L, baseRequestBuilder().build(), principal);
+        assertThat(project.getTitle()).isEqualTo("updated title");
+        assertThat(project.getUser()).isSameAs(owner);
+        projectService.delete(10L, principal);
+        verify(projectRepository).delete(project);
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "ROLE_MEMBER", "ROLE_USER", "ROLE_GUEST" })
+    void 작성자가_아닌_일반_사용자는_수정_조회와_수정_삭제가_금지된다(Role role) {
+        User user = new User();
+        user.setId(2L);
+        user.setRole(role);
+        UserPrincipal principal = principal(2L);
+        Project project = project(owner());
+        when(userRepository.findById(2L)).thenReturn(Optional.of(user));
+        when(projectRepository.findById(10L)).thenReturn(Optional.of(project));
+
+        var details = projectService.getProjectDetails(10L, principal);
+        assertThat(details.getIsOwner()).isFalse();
+        assertThat(details.getCanManage()).isFalse();
+        assertThatThrownBy(() -> projectService.getProjectDetailsForUpdate(10L, principal))
+            .isInstanceOf(ForbiddenException.class);
+        assertThatThrownBy(() -> projectService.update(10L, baseRequestBuilder().build(), principal))
+            .isInstanceOf(ForbiddenException.class);
+        assertThatThrownBy(() -> projectService.delete(10L, principal))
+            .isInstanceOf(ForbiddenException.class);
+        assertThat(project.getTitle()).isEqualTo("old title");
+        verify(projectRepository, never()).delete(project);
+        verifyNoInteractions(objectStorageService);
+    }
+
+    @Test
+    void 비로그인_조회에는_관리_권한이_없고_수정_조회는_금지된다() {
+        when(projectRepository.findById(10L)).thenReturn(Optional.of(project(owner())));
+
+        var details = projectService.getProjectDetails(10L, null);
+        assertThat(details.getIsOwner()).isFalse();
+        assertThat(details.getCanManage()).isFalse();
+        assertThatThrownBy(() -> projectService.getProjectDetailsForUpdate(10L, null))
+            .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    void 관리자도_수정할_때_게시물_비밀번호_검증을_거친다() {
+        UserPrincipal principal = mock(UserPrincipal.class);
+        ProjectRequest request = baseRequestBuilder().password("wrong").build();
+
+        assertThatThrownBy(() -> projectService.update(10L, request, principal))
+            .isInstanceOf(ProjectPasswordInvalidException.class);
+        verifyNoInteractions(projectRepository, objectStorageService);
     }
 
     private ProjectRequest.ProjectRequestBuilder baseRequestBuilder() {


### PR DESCRIPTION
## 📌 관련 이슈

- 연결된 이슈 없음

## ✨ PR 세부 내용

`ROLE_ADMIN` 사용자가 다른 사용자의 프로젝트 게시물도 수정·삭제할 수 있도록 변경했습니다. 기존에는 수정 화면 조회, 수정 저장, 삭제가 모두 작성자에게만 허용되었습니다.

- 서버에서 작성자 또는 `ROLE_ADMIN`에게 수정·삭제 권한을 허용합니다.
- 상세 응답에 `canManage`를 추가하고 화면의 수정·삭제 버튼 표시에 사용합니다. `isOwner`는 실제 작성자 여부를 유지합니다.
- 삭제 화면도 서버 권한을 사용하며, 삭제 API 성공 응답 처리도 수정했습니다.

## 👀 확인해주세요!

- 일반 사용자는 본인이 작성한 게시물만 수정·삭제할 수 있습니다.
- 수정 시 기존 게시물 비밀번호 검증은 유지됩니다.
- 검증: 서버 `ProjectServiceTest` 11개, 화면 `ProjectDetailForm.test.js` 14개 통과.
- 관리자·작성자 허용, 일반 사용자 차단, 비로그인 권한, 수정 화면 이동 및 삭제 동작을 검증했습니다.

## ⌛ 소요 시간

- 별도 측정하지 않음
