### PR TITLE
feat: 2차 팀장 페이지에 1차 확정 팀원 표시

### DIFF
--- a/client/src/assets/TeamBuildRecruit.module.css
+++ b/client/src/assets/TeamBuildRecruit.module.css
@@ -840,3 +840,24 @@
     animation: none;
   }
 }
+
+.recruitedSection {
+  margin-top: 24px;
+}
+
+.recruitedMembers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 0;
+  list-style: none;
+}
+
+.recruitedMember {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+}

--- a/client/src/pages/TeamBuildPage.js
+++ b/client/src/pages/TeamBuildPage.js
@@ -48,6 +48,7 @@ function TeamBuildPage({ round = 1 }) {
   const [currentProjectId, setCurrentProjectId] = useState(null);
   const [projectTitle, setProjectTitle] = useState("");
   const [applies, setApplies] = useState([]);
+  const [recruitedMembers, setRecruitedMembers] = useState([]);
   const [rankedByPosition, setRankedByPosition] = useState(createEmptyRankMap);
   const [capacityByPosition, setCapacityByPosition] = useState(
     createEmptyCapacityMap,
@@ -147,6 +148,7 @@ function TeamBuildPage({ round = 1 }) {
     if (!projectId) return;
     const requestId = ++loadRequestRef.current;
     setIsLoading(true);
+    setRecruitedMembers([]);
     setSubmitMsg("");
     setSubmitStatus("");
     try {
@@ -164,6 +166,7 @@ function TeamBuildPage({ round = 1 }) {
       setCurrentProjectId(projectId);
       setProjectTitle(safeTitle);
       setApplies(normalized);
+      setRecruitedMembers(response?.recruitedMembers || response?.data?.recruitedMembers || []);
       setRankedByPosition(createEmptyRankMap());
       setCapacityByPosition(createEmptyCapacityMap());
       setCurrentFilter("");
@@ -173,6 +176,7 @@ function TeamBuildPage({ round = 1 }) {
       setCurrentProjectId(null);
       setProjectTitle("");
       setApplies([]);
+      setRecruitedMembers([]);
       setRankedByPosition(createEmptyRankMap());
       setCapacityByPosition(createEmptyCapacityMap());
       setCurrentFilter("");
@@ -446,6 +450,7 @@ function TeamBuildPage({ round = 1 }) {
                 setCurrentProjectId(null);
                 setProjectTitle("");
                 setApplies([]);
+                setRecruitedMembers([]);
                 setRankedByPosition(createEmptyRankMap());
                 setCapacityByPosition(createEmptyCapacityMap());
                 setSubmitMsg("");
@@ -465,6 +470,27 @@ function TeamBuildPage({ round = 1 }) {
           </div>
           )}
           {projectTitle && <div className={styles.muted}>· {projectTitle}</div>}
+
+          {round === 2 && currentProjectId && !isLoading && (
+            <section className={styles.recruitedSection} aria-labelledby="recruited-members-title">
+              <h2 id="recruited-members-title" className={styles.sectionTitle}>
+                1차 모집된 팀원 ({recruitedMembers.length}명)
+              </h2>
+              <p className={styles.sectionCaption}>1차 팀빌딩에서 확정된 팀원입니다.</p>
+              {recruitedMembers.length === 0 ? (
+                <p className={styles.muted}>1차에서 모집된 팀원이 없습니다.</p>
+              ) : (
+                <ul className={styles.recruitedMembers}>
+                  {recruitedMembers.map((member) => (
+                    <li key={member.memberId} className={styles.recruitedMember}>
+                      <span>{member.memberName || "알 수 없는 사용자"}</span>
+                      {renderPositionBadge(member.position)}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          )}
 
           <div className={styles.sectionHeader}>
             <div>

--- a/client/src/pages/TeamBuildPage.test.js
+++ b/client/src/pages/TeamBuildPage.test.js
@@ -56,3 +56,47 @@ test("목록 조회 실패 후 다시 시도할 수 있다", async () => {
   await waitFor(() => expect(screen.getByRole("button", { name: "희망 팀 제출하기" })).toBeEnabled());
   expect(teamBuildApi.getRecruitApplies).toHaveBeenCalledWith(42, 1);
 });
+
+const recruitedMembers = [{ memberId: 7, memberName: "기존 팀원", position: "BACKEND" }];
+
+test("2차에서는 신청자가 없어도 1차 확정 팀원과 분야를 표시한다", async () => {
+  teamBuildApi.getRecruitProjects.mockResolvedValue([{ projectId: 42, title: "내 프로젝트" }]);
+  teamBuildApi.getRecruitApplies.mockResolvedValue({ applies: [], recruitedMembers });
+  renderPage(2);
+  expect(await screen.findByRole("heading", { name: "1차 모집된 팀원 (1명)" })).toBeInTheDocument();
+  expect(screen.getByText("기존 팀원")).toBeInTheDocument();
+  expect(screen.getByText("BACKEND")).toBeInTheDocument();
+  expect(screen.getByText("기존 팀원").closest("[draggable]")).toBeNull();
+  expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
+});
+
+test("1차 페이지에는 기존 팀원 영역을 표시하지 않는다", async () => {
+  teamBuildApi.getRecruitProjects.mockResolvedValue([{ projectId: 42, title: "내 프로젝트" }]);
+  teamBuildApi.getRecruitApplies.mockResolvedValue({ applies: [], recruitedMembers });
+  renderPage(1);
+  await waitFor(() => expect(screen.getByRole("button", { name: "희망 팀 제출하기" })).toBeEnabled());
+  expect(screen.queryByText("기존 팀원")).not.toBeInTheDocument();
+});
+
+test("2차에서 확정 팀원이 없으면 안내한다", async () => {
+  teamBuildApi.getRecruitProjects.mockResolvedValue([{ projectId: 42, title: "내 프로젝트" }]);
+  renderPage(2);
+  expect(await screen.findByText("1차에서 모집된 팀원이 없습니다.")).toBeInTheDocument();
+});
+
+test("프로젝트를 바꾸면 이전 프로젝트의 확정 팀원을 지운다", async () => {
+  teamBuildApi.getRecruitProjects.mockResolvedValue([
+    { projectId: 42, title: "첫 프로젝트" }, { projectId: 99, title: "둘째 프로젝트" },
+  ]);
+  teamBuildApi.getRecruitApplies.mockResolvedValueOnce({ applies: [], recruitedMembers })
+    .mockResolvedValueOnce({ applies: [], recruitedMembers: [] });
+  renderPage(2);
+  const select = await screen.findByRole("combobox", { name: "모집할 프로젝트" });
+  fireEvent.change(select, { target: { value: "42" } });
+  fireEvent.click(screen.getByRole("button", { name: "불러오기" }));
+  expect(await screen.findByText("기존 팀원")).toBeInTheDocument();
+  fireEvent.change(select, { target: { value: "99" } });
+  expect(screen.queryByText("기존 팀원")).not.toBeInTheDocument();
+  fireEvent.click(screen.getByRole("button", { name: "불러오기" }));
+  expect(await screen.findByText("1차에서 모집된 팀원이 없습니다.")).toBeInTheDocument();
+});

--- a/server/src/main/java/wap/web2/server/teambuild/dto/response/ProjectAppliesResponse.java
+++ b/server/src/main/java/wap/web2/server/teambuild/dto/response/ProjectAppliesResponse.java
@@ -13,6 +13,20 @@ public class ProjectAppliesResponse {
 
     private List<ApplyResponse> applies;
 
+    private List<RecruitedMemberResponse> recruitedMembers = List.of();
+
+    public ProjectAppliesResponse(List<ApplyResponse> applies) {
+        this.applies = applies;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class RecruitedMemberResponse {
+        private Long memberId;
+        private String memberName;
+        private String position;
+    }
+
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor

--- a/server/src/main/java/wap/web2/server/teambuild/repository/TeamRepository.java
+++ b/server/src/main/java/wap/web2/server/teambuild/repository/TeamRepository.java
@@ -9,5 +9,7 @@ import wap.web2.server.teambuild.entity.Team;
 public interface TeamRepository extends JpaRepository<Team, Long> {
     List<Team> findAllBySemester(String semester);
 
+    List<Team> findAllByProjectIdAndSemesterAndRoundOrderByIdAsc(Long projectId, String semester, int round);
+
     void deleteBySemester(String semester);
 }

--- a/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
+++ b/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
@@ -7,6 +7,11 @@ import java.util.List;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import wap.web2.server.teambuild.entity.Team;
+import wap.web2.server.teambuild.repository.TeamRepository;
+import wap.web2.server.teambuild.dto.response.ProjectAppliesResponse.RecruitedMemberResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -47,6 +52,7 @@ public class ApplyService {
     private final ProjectApplyRepository applyRepository;
     private final ProjectRepository projectRepository;
     private final UserRepository userRepository;
+    private final TeamRepository teamRepository;
 
     @Transactional
     public void apply(UserPrincipal userPrincipal, ProjectAppliesRequest request) {
@@ -154,7 +160,20 @@ public class ApplyService {
             throw new ConflictException("이미 제출된 모집이 존재합니다.");
         }
 
-        return getApplies(userPrincipal, projectId, round);
+        ProjectAppliesResponse response = getApplies(userPrincipal, projectId, round);
+        if (round == 1) return response;
+
+        List<Team> teams = teamRepository.findAllByProjectIdAndSemesterAndRoundOrderByIdAsc(
+            projectId, generateSemester(), 1);
+        Map<Long, User> members = userRepository.findAllById(
+            teams.stream().map(Team::getMemberId).distinct().toList()).stream()
+            .collect(Collectors.toMap(User::getId, member -> member));
+        List<RecruitedMemberResponse> recruitedMembers = teams.stream()
+            .map(team -> new RecruitedMemberResponse(team.getMemberId(),
+                members.containsKey(team.getMemberId()) ? members.get(team.getMemberId()).getName() : "알 수 없는 사용자",
+                team.getPosition().name()))
+            .toList();
+        return new ProjectAppliesResponse(response.getApplies(), recruitedMembers);
     }
 
     @Transactional

--- a/server/src/test/java/wap/web2/server/teambuild/service/ApplyRoundTest.java
+++ b/server/src/test/java/wap/web2/server/teambuild/service/ApplyRoundTest.java
@@ -43,6 +43,7 @@ class ApplyRoundTest {
     @Mock ProjectApplyRepository applyRepository;
     @Mock ProjectRepository projectRepository;
     @Mock UserRepository userRepository;
+    @Mock wap.web2.server.teambuild.repository.TeamRepository teamRepository;
     @InjectMocks ApplyService service;
 
     UserPrincipal principal;
@@ -146,11 +147,34 @@ class ApplyRoundTest {
     }
 
     @Test
+    void secondRoundPageIncludesConfirmedFirstRoundMembersWithoutApplicants() {
+        owner();
+        User member = new User();
+        member.setId(2L);
+        member.setName("기존 팀원");
+        when(teamRepository.findAllByProjectIdAndSemesterAndRoundOrderByIdAsc(10L, generateSemester(), 1))
+            .thenReturn(List.of(wap.web2.server.teambuild.entity.Team.builder()
+                .projectId(10L).memberId(2L).position(wap.web2.server.teambuild.entity.Position.BACKEND)
+                .round(1).semester(generateSemester()).build()));
+        when(userRepository.findAllById(List.of(2L))).thenReturn(List.of(member));
+
+        var response = service.getRecruitPageData(principal, 10L, 2);
+
+        assertThat(response.getApplies()).isEmpty();
+        assertThat(response.getRecruitedMembers()).singleElement().satisfies(recruited -> {
+            assertThat(recruited.getMemberId()).isEqualTo(2L);
+            assertThat(recruited.getMemberName()).isEqualTo("기존 팀원");
+            assertThat(recruited.getPosition()).isEqualTo("BACKEND");
+        });
+    }
+
+    @Test
     void legacyPageUsesFirstRound() {
         owner();
         when(applyRepository.findAllByProjectAndSemesterAndRound(project, generateSemester(), 1))
             .thenReturn(List.of());
-        service.getRecruitPageData(principal, 10L);
+        assertThat(service.getRecruitPageData(principal, 10L).getRecruitedMembers()).isEmpty();
+        verifyNoInteractions(teamRepository);
         verify(recruitRepository).existsByProjectIdAndSemesterAndRound(10L, generateSemester(), 1);
         verify(applyRepository).findAllByProjectAndSemesterAndRound(project, generateSemester(), 1);
         assertThat(ProjectApply.builder().build().getRound()).isEqualTo(1);

--- a/server/src/test/java/wap/web2/server/teambuild/service/SubmissionLockIntegrationTest.java
+++ b/server/src/test/java/wap/web2/server/teambuild/service/SubmissionLockIntegrationTest.java
@@ -77,7 +77,8 @@ class SubmissionLockIntegrationTest {
         metas = new JpaRepositoryFactory(entityManager).getRepository(TeamBuildingMetaRepository.class);
         var transactionManager = new JpaTransactionManager(factory.getObject());
         transaction = new TransactionTemplate(transactionManager);
-        var proxy = new ProxyFactory(new ApplyService(metas, wishes, recruits, applies, projects, users));
+        var proxy = new ProxyFactory(new ApplyService(metas, wishes, recruits, applies, projects, users,
+            mock(wap.web2.server.teambuild.repository.TeamRepository.class)));
         proxy.addAdvice(new TransactionInterceptor(transactionManager, new AnnotationTransactionAttributeSource()));
         service = (ApplyService) proxy.getProxy();
         User user = new User();


### PR DESCRIPTION
## 📌 관련 이슈

- 별도 연결 이슈 없음

## ✨ PR 세부 내용

2차 팀장 모집 페이지에서 1차에 이미 확정된 팀원을 확인할 수 있도록 했습니다.

- 모집 조회 API에 해당 학기·프로젝트의 1차 확정 팀원 정보를 추가했습니다.
- 2차 페이지에 기존 팀원의 이름, 분야, 인원수를 표시합니다. 2차 신청자가 없어도 확인할 수 있습니다.
- 확정 팀원이 없으면 안내 문구를 표시하고, 프로젝트 변경 시 이전 팀원 목록을 초기화합니다.
- 기존 누적 배정 방식은 유지합니다.

## 👀 확인해주세요!

- 서버: `ApplyRoundTest`, `SubmissionLockIntegrationTest` 통과
- 프론트엔드: 관련 테스트 3개 스위트, 35개 테스트 통과
- 1차 페이지에는 기존 팀원 영역이 표시되지 않는지, 프로젝트 전환 시 목록이 갱신되는지 검증했습니다.

## ⌛ 소요 시간

- 미기록
