### PR TITLE
feat: 프로젝트 기타 유형 표시 수정

### DIFF
--- a/client/src/components/ContentBox.js
+++ b/client/src/components/ContentBox.js
@@ -21,7 +21,7 @@ const getTypeLabel = (type) => {
     web: "웹",
     app: "앱",
     game: "게임",
-    기타: "임베디드",
+    기타: "기타",
   };
   return typeMap[type?.toLowerCase?.()] || type;
 };

--- a/client/src/components/ContentBox.js
+++ b/client/src/components/ContentBox.js
@@ -12,7 +12,7 @@ const TYPE_OPTIONS = [
   { label: "웹", value: "Web" },
   { label: "앱", value: "App" },
   { label: "게임", value: "Game" },
-  { label: "임베디드", value: "기타" },
+  { label: "기타", value: "기타" },
 ];
 
 // 프로젝트 타입을 한글로 변환하는 함수


### PR DESCRIPTION
## 📌 관련 이슈

- 없음

## ✨ PR 세부 내용

팀 생성 시 프로젝트 유형을 '기타'로 선택해도 프로젝트 목록에서 '임베디드'로 표시되던 문제를 수정합니다.

- 프로젝트 카드의 유형을 '기타'로 표시합니다.
- 프로젝트 유형 필터 버튼을 '기타'로 표시합니다.
- 저장 값과 필터 조건은 유지하고, 카드 표시와 필터 표시 변경을 각각 별도 커밋으로 분리했습니다.

## 👀 확인해주세요!

- `git diff --check` 통과
- `client`에서 `npm run build` 실행 시 기존 `src/components/ProjectCreation/RadioButton.js`의 `import { React } from "react"` 오류로 빌드 실패

## ⌛ 소요 시간

- 별도 측정하지 않음
