### PR TITLE
feat: 3차 팀빌딩에서 기존 팀원 배치 수정 지원

### DIFF
--- a/client/src/pages/adminPages/ManageThirdTeamBuildPage.js
+++ b/client/src/pages/adminPages/ManageThirdTeamBuildPage.js
@@ -230,7 +230,7 @@ const ManageThirdTeamBuildPage = () => {
     }
   };
 
-  const renderPositionSlot = (member) => (
+  const renderMember = (member) => (
     <button
       key={member.id}
       type="button"
@@ -309,7 +309,8 @@ const ManageThirdTeamBuildPage = () => {
           3차 팀빌딩
         </h1>
         <p className={styles.description}>
-          팀별 배정이 완료된 멤버와 담당 직무를 확인하세요.
+          기존 팀원을 포함한 전체 멤버의 담당 직무를 확인하고 팀 배치를
+          수정하세요.
         </p>
         <p className={styles.notice}>
           {completed
@@ -376,8 +377,9 @@ const ManageThirdTeamBuildPage = () => {
           팀 빌딩 완료
         </button>
         <p id="shuffle-help" className={styles.description}>
-          같은 직무 지원자를 미배정 목록과 팀 사이에서 무작위로 섞습니다. 팀별
-          직무 인원수는 유지되며, 결과가 기존 배치와 같을 수도 있습니다.
+          기존 팀원을 포함해 같은 직무의 멤버를 미배정 목록과 팀 사이에서
+          무작위로 섞습니다. 팀별 직무 인원수는 유지되며, 결과가 기존 배치와
+          같을 수도 있습니다.
         </p>
       </div>
 
@@ -404,12 +406,12 @@ const ManageThirdTeamBuildPage = () => {
           미배정 멤버
         </h2>
         <p id="assignment-help" className={styles.description}>
-          지원자를 팀 카드로 드래그하거나 선택 후 팀 카드를 클릭하세요. 각
-          항목은 지원자의 이름과 주요 직무를 나타냅니다. 배치한 지원자도 같은
-          방법으로 다른 팀이나 미배정 멤버 섹션으로 이동할 수 있습니다.
+          기존 팀원과 새로 배치한 멤버 모두 팀 카드로 드래그하거나 선택 후 팀
+          카드를 클릭해 이동할 수 있습니다. 각 항목은 이름과 담당 직무를
+          나타냅니다. 미배정 멤버 섹션으로 이동해 배정을 해제할 수도 있습니다.
         </p>
         <div className={styles.unassignedList}>
-          {unassigned.map((member) => renderPositionSlot(member))}
+          {unassigned.map((member) => renderMember(member))}
         </div>
         {!loading && revision !== null && unassigned.length === 0 && (
           <p className={styles.description}>
@@ -493,7 +495,7 @@ const ManageThirdTeamBuildPage = () => {
                   {team.members.map((member) => (
                     <tr key={member.id}>
                       {member.type === "POSITION_SLOT" ? (
-                        <td colSpan={2}>{renderPositionSlot(member)}</td>
+                        <td colSpan={2}>{renderMember(member)}</td>
                       ) : (
                         <>
                           <td>

--- a/client/src/pages/adminPages/ManageThirdTeamBuildPage.test.js
+++ b/client/src/pages/adminPages/ManageThirdTeamBuildPage.test.js
@@ -35,7 +35,11 @@ beforeEach(() => {
       ...team,
       id: team.projectId,
       isCreated: false,
-      members: [...team.members],
+      members: team.members.map((member) => ({
+        ...member,
+        id: `slot-existing-${member.id}`,
+        type: "POSITION_SLOT",
+      })),
     })),
     unassigned: [...thirdRoundPositionSlots],
   };
@@ -235,7 +239,7 @@ test("클릭으로 선택한 멤버를 기존 팀에 추가한다", async () => 
   const team = within(getTeam("WAPs"));
   expect(team.getByRole("row", { name: "BACKEND" })).toBeInTheDocument();
   expect(team.queryAllByRole("row").slice(1)).toHaveLength(5);
-  expect(team.getByText("김민준")).toBeInTheDocument();
+  expect(team.getByText("김민준(FRONTEND)")).toBeInTheDocument();
   expect(within(getUnassigned()).getAllByRole("button")).toHaveLength(8);
 });
 
@@ -399,7 +403,9 @@ test("팀을 생성하면 빈 카드가 추가되고 기존 명단과 미배정 
   expect(
     within(getTeam("팀 A")).getByText("아직 배정된 멤버가 없습니다."),
   ).toBeInTheDocument();
-  expect(within(getTeam("WAPs")).getByText("김민준")).toBeInTheDocument();
+  expect(
+    within(getTeam("WAPs")).getByText("김민준(FRONTEND)"),
+  ).toBeInTheDocument();
   expect(within(getUnassigned()).getAllByRole("button")).toHaveLength(9);
   expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
 });
@@ -749,3 +755,57 @@ test("팀 카드에 배정 완료 인원 대신 프로젝트 분야를 표시한
     within(getTeam("팀 A")).queryByText(/WEB|배정 완료/),
   ).not.toBeInTheDocument();
 });
+
+test.each(["click", "Enter", " ", "drag"])(
+  "기존 팀원을 다른 팀과 미배정 목록으로 이동하고 재방문 시 복원한다 (%s)",
+  async (method) => {
+    const member = savedBoard.teams[0].members[0];
+    const label = `${member.name}(${member.position})`;
+    const originalTeam = savedBoard.teams[0].teamName;
+    const page = render(<ManageThirdTeamBuildPage />);
+    await settle();
+    const source = within(getTeam(originalTeam)).getByRole("button", {
+      name: label,
+    });
+    if (method === "drag") {
+      fireEvent.pointerDown(source, { button: 0, clientX: 10, clientY: 10 });
+      document.elementFromPoint = jest.fn(() => getTeam("오늘의 기록"));
+      fireEvent.pointerMove(source, { clientX: 100, clientY: 200 });
+      fireEvent.pointerUp(source, { clientX: 100, clientY: 200 });
+    } else {
+      fireEvent.click(source);
+      const target = screen.getByRole("button", { name: "오늘의 기록" });
+      if (method === "click") fireEvent.click(target);
+      else fireEvent.keyDown(target, { key: method });
+    }
+    await settle();
+    expect(thirdRoundApi.move).toHaveBeenLastCalledWith(
+      member.id,
+      Number(getTeam("오늘의 기록").dataset.teamId),
+      0,
+    );
+    expect(
+      within(getTeam(originalTeam)).queryByRole("button", { name: label }),
+    ).not.toBeInTheDocument();
+    const movedMember = within(getTeam("오늘의 기록")).getByRole("button", {
+      name: label,
+    });
+    fireEvent.pointerDown(movedMember, { button: 0, clientX: 10, clientY: 10 });
+    fireEvent.pointerUp(movedMember, { clientX: 10, clientY: 10 });
+    fireEvent.click(movedMember);
+    fireEvent.click(screen.getByRole("button", { name: "미배정 멤버" }));
+    await settle();
+    expect(thirdRoundApi.move).toHaveBeenLastCalledWith(member.id, null, 1);
+    page.unmount();
+    render(<ManageThirdTeamBuildPage />);
+    await settle();
+    fireEvent.click(
+      within(getUnassigned()).getByRole("button", { name: label }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: originalTeam }));
+    await settle();
+    expect(
+      within(getTeam(originalTeam)).getByRole("button", { name: label }),
+    ).toBeInTheDocument();
+  },
+);

--- a/server/src/main/java/wap/web2/server/admin/service/ThirdRoundPlanService.java
+++ b/server/src/main/java/wap/web2/server/admin/service/ThirdRoundPlanService.java
@@ -97,14 +97,19 @@ public class ThirdRoundPlanService {
     public ThirdRoundBoardResponse complete(long revision) {
         ThirdRoundPlan plan = editable(revision);
         String semester = plan.getSemester();
-        List<ThirdRoundPositionSlot> positions = slots.findAllBySemesterOrderById(semester);
+        List<ThirdRoundPositionSlot> positions = new ArrayList<>(slots.findAllBySemesterOrderById(semester));
         List<Team> existing = teams.findAllBySemester(semester);
         identifyLegacySlots(semester, positions, existing);
         Map<Long, Project> currentProjects = projects.findProjectsBySemester(semester).stream()
             .collect(Collectors.toMap(Project::getProjectId, p -> p));
         Map<Long, ThirdRoundPlanTeam> cards = planTeams.findAllBySemesterOrderById(semester).stream()
             .collect(Collectors.toMap(ThirdRoundPlanTeam::getId, c -> c));
-        Set<Long> allocated = existing.stream().map(Team::getMemberId).collect(Collectors.toSet());
+        includeExistingMembers(semester, positions, existing, new ArrayList<>(cards.values()));
+        Set<Long> represented = positions.stream().map(ThirdRoundPositionSlot::getUserId)
+            .filter(Objects::nonNull).collect(Collectors.toSet());
+        Set<Long> allocated = existing.stream().map(Team::getMemberId)
+            .filter(id -> !represented.contains(id)).collect(Collectors.toSet());
+        Set<Team> retained = new HashSet<>();
         currentProjects.values().forEach(p -> allocated.add(p.getUser().getId()));
         List<ThirdRoundPositionSlot> assigned = positions.stream().filter(s -> s.getTeamId() != null).toList();
         Set<Long> validUsers = users.findAllById(assigned.stream().map(ThirdRoundPositionSlot::getUserId)
@@ -120,11 +125,21 @@ public class ThirdRoundPlanService {
             if (card.getProjectId() != null) {
                 Project project = currentProjects.get(card.getProjectId());
                 if (project == null) throw new ConflictException("기존 프로젝트를 찾을 수 없습니다.");
+                Team unchanged = existing.stream().filter(t -> t.getMemberId().equals(slot.getUserId())
+                    && t.getProjectId().equals(project.getProjectId()) && t.getPosition() == slot.getPosition())
+                    .findFirst().orElse(null);
+                if (unchanged != null) {
+                    retained.add(unchanged);
+                    continue;
+                }
                 allocation.add(Team.builder().projectId(project.getProjectId())
                     .leaderId(project.getUser().getId()).memberId(slot.getUserId())
                     .position(slot.getPosition()).round(3).semester(semester).build());
             }
         }
+        teams.deleteAll(existing.stream().filter(t -> represented.contains(t.getMemberId())
+            && !retained.contains(t)).toList());
+        teams.flush();
         teams.saveAll(allocation);
         plan.complete();
         lockMeta(semester).completeThirdRound();
@@ -137,7 +152,9 @@ public class ThirdRoundPlanService {
 
     ThirdRoundBoardResponse shuffle(long revision, Random random) {
         ThirdRoundPlan plan = editable(revision);
-        List<ThirdRoundPositionSlot> positions = slots.findAllBySemesterOrderById(plan.getSemester());
+        List<ThirdRoundPositionSlot> positions = new ArrayList<>(slots.findAllBySemesterOrderById(plan.getSemester()));
+        includeExistingMembers(plan.getSemester(), positions, teams.findAllBySemester(plan.getSemester()),
+            planTeams.findAllBySemesterOrderById(plan.getSemester()));
         identifyLegacySlots(plan.getSemester(), positions, teams.findAllBySemester(plan.getSemester()));
         Map<Position, List<ThirdRoundPositionSlot>> groups = positions.stream()
             .filter(slot -> slot.getUserId() != null)
@@ -204,9 +221,14 @@ public class ThirdRoundPlanService {
     private ThirdRoundBoardResponse board(ThirdRoundPlan plan) {
         String semester = plan.getSemester();
         List<ThirdRoundPlanTeam> cards = planTeams.findAllBySemesterOrderById(semester);
-        List<ThirdRoundPositionSlot> positions = slots.findAllBySemesterOrderById(semester);
+        List<ThirdRoundPositionSlot> positions = new ArrayList<>(slots.findAllBySemesterOrderById(semester));
         List<Team> existing = teams.findAllBySemester(semester);
-        if (!plan.isCompleted()) identifyLegacySlots(semester, positions, existing);
+        if (!plan.isCompleted()) {
+            identifyLegacySlots(semester, positions, existing);
+            includeExistingMembers(semester, positions, existing, cards);
+        }
+        Set<Long> represented = positions.stream().map(ThirdRoundPositionSlot::getUserId)
+            .filter(Objects::nonNull).collect(Collectors.toSet());
         Set<Long> userIds = existing.stream().map(Team::getMemberId).collect(Collectors.toSet());
         positions.stream().map(ThirdRoundPositionSlot::getUserId).filter(Objects::nonNull).forEach(userIds::add);
         Map<Long, User> members = users.findAllById(new ArrayList<>(userIds))
@@ -218,7 +240,7 @@ public class ThirdRoundPlanService {
             List<Member> roster = new ArrayList<>();
             if (card.getProjectId() != null) {
                 existing.stream().filter(t -> t.getProjectId().equals(card.getProjectId()))
-                    .filter(t -> !plan.isCompleted() || t.getRound() != 3).forEach(t -> {
+                    .filter(t -> !represented.contains(t.getMemberId())).forEach(t -> {
                     User user = members.get(t.getMemberId());
                     if (user == null) throw new ResourceNotFoundException("배정된 사용자를 찾을 수 없습니다.");
                     roster.add(new Member("member-" + user.getId(), "MEMBER", user.getName(), t.getPosition()));
@@ -234,6 +256,23 @@ public class ThirdRoundPlanService {
         }
         return new ThirdRoundBoardResponse(semester, plan.getRevision(), result,
             positions.stream().filter(s -> s.getTeamId() == null).map(s -> slotView(s, members)).toList(), plan.isCompleted());
+    }
+
+    /** Upgrade existing drafts without resetting any saved moves or unassignments. */
+    private void includeExistingMembers(String semester, List<ThirdRoundPositionSlot> positions,
+                                        List<Team> existing, List<ThirdRoundPlanTeam> cards) {
+        Set<Long> represented = positions.stream().map(ThirdRoundPositionSlot::getUserId)
+            .filter(Objects::nonNull).collect(Collectors.toSet());
+        Map<Long, Long> cardIds = cards.stream().filter(c -> c.getProjectId() != null)
+            .collect(Collectors.toMap(ThirdRoundPlanTeam::getProjectId, ThirdRoundPlanTeam::getId));
+        for (Team member : existing) {
+            Long cardId = cardIds.get(member.getProjectId());
+            if (cardId == null || !represented.add(member.getMemberId())) continue;
+            ThirdRoundPositionSlot slot = new ThirdRoundPositionSlot(semester, member.getPosition());
+            slot.identify(member.getMemberId());
+            slot.moveTo(cardId);
+            positions.add(slots.save(slot));
+        }
     }
 
     private void identifyLegacySlots(String semester, List<ThirdRoundPositionSlot> positions, List<Team> existing) {

--- a/server/src/test/java/wap/web2/server/admin/service/ThirdRoundPlanServiceTest.java
+++ b/server/src/test/java/wap/web2/server/admin/service/ThirdRoundPlanServiceTest.java
@@ -5,6 +5,9 @@ import static org.mockito.Mockito.*;
 import static wap.web2.server.util.SemesterGenerator.generateSemester;
 import java.util.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -285,7 +288,10 @@ class ThirdRoundPlanServiceTest {
         assertThatThrownBy(() -> service.complete(0)).isInstanceOf(ConflictException.class);
         slot.identify(12L);
         when(users.findAllById(any())).thenReturn(List.of(user(12)));
-        when(teams.findAllBySemester(semester)).thenReturn(List.of(Team.builder().memberId(12L).build()));
+        ThirdRoundPositionSlot duplicate = slot(2, semester);
+        duplicate.identify(12L); duplicate.moveTo(20L);
+        when(slots.findAllBySemesterOrderById(semester)).thenReturn(List.of(slot, duplicate));
+        when(planTeams.findAllBySemesterOrderById(semester)).thenReturn(List.of(card(20, null, semester)));
         assertThatThrownBy(() -> service.complete(0)).isInstanceOf(ConflictException.class);
         verify(teams, never()).saveAll(any());
         assertThat(plan.isCompleted()).isFalse();
@@ -309,7 +315,7 @@ class ThirdRoundPlanServiceTest {
         assertThat(board.unassigned()).isEmpty();
     }
 
-    @Test void boardKeepsRealMemberNamesButSlotsHaveNoNameOrUserId() {
+    @Test void boardUpgradesExistingMembersToEditableSlotsAndPreservesAnonymousSlots() {
         ready();
         when(planTeams.findAllBySemesterOrderById(semester)).thenReturn(List.of(card(20, 100L, semester)));
         ThirdRoundPositionSlot slot = slot(1, semester); slot.moveTo(20L);
@@ -317,11 +323,74 @@ class ThirdRoundPlanServiceTest {
         when(teams.findAllBySemester(semester)).thenReturn(List.of(Team.builder()
             .projectId(100L).memberId(11L).position(Position.AI).build()));
         when(users.findAllById(List.of(11L))).thenReturn(List.of(user(11)));
+        when(slots.save(any())).thenAnswer(call -> {
+            ThirdRoundPositionSlot saved = call.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 2L);
+            return saved;
+        });
         var board = service.get();
         assertThat(board.teams().get(0).members()).hasSize(2);
-        assertThat(board.teams().get(0).members().get(0).name()).isEqualTo("기존 멤버");
-        var anonymous = board.teams().get(0).members().get(1);
+        assertThat(board.teams().get(0).members().get(1).name()).isEqualTo("기존 멤버");
+        assertThat(board.teams().get(0).members().get(1).type()).isEqualTo("POSITION_SLOT");
+        var anonymous = board.teams().get(0).members().get(0);
         assertThat(anonymous.name()).isNull();
         assertThat(anonymous.id()).isEqualTo("slot-1");
     }
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(longs = {20, 30, 40})
+    void existingMemberMovesPersistInDraftAndPublishOnlyOnCompletion(Long destination) {
+        ready();
+        User owner = user(10), member = user(11);
+        when(projects.findProjectsBySemester(semester)).thenReturn(List.of(
+            Project.builder().projectId(100L).user(owner).build(),
+            Project.builder().projectId(200L).user(owner).build()));
+        var original = card(20, 100L, semester);
+        var other = card(30, 200L, semester);
+        var created = card(40, null, semester);
+        when(planTeams.findAllBySemesterOrderById(semester)).thenReturn(List.of(original, other, created));
+        Team allocation = Team.builder().projectId(100L).memberId(11L).leaderId(10L)
+            .position(Position.FRONTEND).semester(semester).round(2).build();
+        List<Team> published = new ArrayList<>(List.of(allocation));
+        when(teams.findAllBySemester(semester)).thenAnswer(call -> new ArrayList<>(published));
+        List<ThirdRoundPositionSlot> persisted = new ArrayList<>();
+        when(slots.findAllBySemesterOrderById(semester)).thenAnswer(call -> new ArrayList<>(persisted));
+        when(slots.save(any())).thenAnswer(call -> {
+            ThirdRoundPositionSlot saved = call.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 1L);
+            persisted.add(saved);
+            return saved;
+        });
+        when(users.findAllById(any())).thenReturn(List.of(member));
+        assertThat(service.open().teams().get(0).members()).singleElement()
+            .satisfies(m -> assertThat(m.type()).isEqualTo("POSITION_SLOT"));
+        when(slots.findById(1L)).thenReturn(Optional.of(persisted.get(0)));
+        if (destination != null) when(planTeams.findById(destination)).thenReturn(Optional.of(
+            destination == 20 ? original : destination == 30 ? other : created));
+        var moved = service.move(1, destination, 0);
+        service.open();
+        assertThat(persisted).hasSize(1);
+        assertThat(persisted.get(0).getTeamId()).isEqualTo(destination);
+        verify(teams, never()).deleteAll(any());
+        verify(teams, never()).saveAll(any());
+        doAnswer(call -> { published.removeAll(call.getArgument(0)); return null; })
+            .when(teams).deleteAll(any());
+        when(teams.saveAll(any())).thenAnswer(call -> {
+            List<Team> saved = call.getArgument(0); published.addAll(saved); return saved;
+        });
+        var completed = service.complete(moved.revision());
+        assertThat(completed.completed()).isTrue();
+        if (destination == null || destination == 40) assertThat(published).isEmpty();
+        else assertThat(published).singleElement().satisfies(t -> {
+            assertThat(t.getProjectId()).isEqualTo(destination == 20 ? 100L : 200L);
+            assertThat(t.getRound()).isEqualTo(destination == 20 ? 2 : 3);
+            assertThat(t.getMemberId()).isEqualTo(11L);
+        });
+        assertThat(completed.unassigned()).hasSize(destination == null ? 1 : 0);
+        assertThat(completed.teams().stream().mapToInt(t -> t.members().size()).sum())
+            .isEqualTo(destination == null ? 0 : 1);
+        service.open();
+        verify(slots).save(any());
+    }
+
 }


### PR DESCRIPTION
## 📌 관련 이슈

- 별도 연결 이슈 없음

## ✨ PR 세부 내용

3차 팀빌딩에서 읽기 전용이었던 기존 팀원도 다른 팀이나 미배정 목록으로 이동할 수 있도록 변경했습니다. 기존 배치안을 다시 열어도 저장된 이동 내역을 유지하며, 팀 빌딩 완료 시 최종 결과에 반영합니다.

- 기존 팀원을 편집 가능한 배치안에 포함하고, 같은 직무 셔플에도 포함합니다.
- 기존 프로젝트 간 이동, 새 팀으로 이동, 배정 해제를 지원합니다.
- 이동하지 않은 팀원의 기존 배정 차수를 유지합니다.
- 화면 안내를 수정하고 클릭·키보드·드래그 및 재방문 복원 테스트를 보완했습니다.

## 👀 확인해주세요!

- 배치안은 자동 저장되며 최종 결과는 팀 빌딩 완료 시 반영됩니다. 완료 후 편집 제한은 유지됩니다.
- 서버: `./gradlew test --tests '*ThirdRoundPlanServiceTest' --tests '*AdminThirdRoundPlanControllerTest' --tests '*TeamBuildingResultServiceTest'` 통과
- 클라이언트: `npm test -- --watchAll=false --runInBand --runTestsByPath src/pages/adminPages/ManageThirdTeamBuildPage.test.js` 39개 통과
- DB 통합 테스트는 실행하지 않았습니다.

## ⌛ 소요 시간

- 별도 측정하지 않음
