### PR TITLE
feat: 관리자 팀 빌딩 완전 초기화 기능 추가

### DIFF
--- a/client/src/api/admin.js
+++ b/client/src/api/admin.js
@@ -81,4 +81,6 @@ export const adminTeamBuildApi = {
 
   // 현재 학기 배정 결과와 진행 단계 초기화
   resetTeamBuild: () => apiClient.post("/admin/team/building/reset/current"),
+  // 현재 학기의 모든 차수 지원·모집을 포함한 완전 초기화
+  resetTeamBuildCompletely: () => apiClient.post("/admin/team/building/reset/current/complete"),
 };

--- a/client/src/assets/Admin/ManageTeamBuild.module.css
+++ b/client/src/assets/Admin/ManageTeamBuild.module.css
@@ -152,3 +152,5 @@
   .stageActions { justify-content: space-between; }
   .previousBtn, .nextBtn { padding: 10px 12px; }
 }
+
+.resetActions { display: flex; flex-wrap: wrap; gap: 8px; }

--- a/client/src/components/ProjectCreation/RadioButton.js
+++ b/client/src/components/ProjectCreation/RadioButton.js
@@ -1,4 +1,4 @@
-import { React } from "react";
+import React from "react";
 import styles from "../../assets/ProjectCreation/RadioButton.module.css"; // CSS 파일 경로 추가
 
 const RadioButton = ({ labelname, name, options, selected, setSelected }) => {

--- a/client/src/pages/adminPages/ManageTeamBuildPage.js
+++ b/client/src/pages/adminPages/ManageTeamBuildPage.js
@@ -13,7 +13,7 @@ const ManageTeamBuildPage = () => {
   const [status, setStatus] = useState("unavailable"); // 현재 팀빌딩 상태
   const [statusLoading, setStatusLoading] = useState(true); // 팀빌딩 상태 로드 여부
   const [statusChanging, setStatusChanging] = useState(false); // 상태 변경 중 여부(버튼 중복 클릭 방지)
-  const [resetting, setResetting] = useState(false);
+  const [resetting, setResetting] = useState(null);
   const semester = useSemester();
 
   const statusSteps = [
@@ -60,20 +60,25 @@ const ManageTeamBuildPage = () => {
     setStatusChanging(false);
   };
 
-  const handleResetTeamBuild = async () => {
+  const handleResetTeamBuild = async (complete = false) => {
     if (status === "unavailable" || statusLoading || statusChanging || loading) return;
-    if (!window.confirm(
-      `${semester} 팀 빌딩을 초기화하시겠습니까?\n배정 결과와 3차 분류 정보가 삭제되고 시작 단계로 돌아갑니다.\n지원·모집 데이터는 유지됩니다. 삭제한 결과는 복구할 수 없습니다.`,
-    )) return;
+    const message = complete
+      ? `${semester} 팀 빌딩을 완전 초기화하시겠습니까?\n모든 차수의 지원·모집 데이터(희망 지원자 포함), 배정 결과와 3차 분류 정보가 삭제되고 시작 단계로 돌아갑니다.\n프로젝트 글은 유지됩니다. 삭제한 데이터는 복구할 수 없습니다.`
+      : `${semester} 팀 빌딩을 초기화하시겠습니까?\n배정 결과와 3차 분류 정보가 삭제되고 시작 단계로 돌아갑니다.\n지원·모집 데이터는 유지됩니다. 삭제한 결과는 복구할 수 없습니다.`;
+    if (!window.confirm(message)) return;
     setStatusChanging(true);
-    setResetting(true);
+    setResetting(complete ? "complete" : "results");
     try {
-      await adminTeamBuildApi.resetTeamBuild();
+      if (complete) {
+        await adminTeamBuildApi.resetTeamBuildCompletely();
+      } else {
+        await adminTeamBuildApi.resetTeamBuild();
+      }
       await fetchStatus();
     } catch (e) {
-      alert("팀 빌딩 초기화에 실패했습니다.");
+      alert(complete ? "팀 빌딩 완전 초기화에 실패했습니다." : "팀 빌딩 초기화에 실패했습니다.");
     } finally {
-      setResetting(false);
+      setResetting(null);
       setStatusChanging(false);
     }
   };
@@ -175,10 +180,16 @@ const ManageTeamBuildPage = () => {
               <span className={styles.progressEyebrow}>{semester}</span>
               <h2>TEAM BUILDING</h2>
             </div>
-            <button className={styles.resetBtn} onClick={handleResetTeamBuild}
-              disabled={status === "unavailable" || statusLoading || statusChanging || loading}>
-              <FiRotateCcw aria-hidden="true" /> {resetting ? "초기화 중..." : "팀 빌딩 초기화"}
-            </button>
+            <div className={styles.resetActions}>
+              <button className={styles.resetBtn} onClick={() => handleResetTeamBuild()}
+                disabled={status === "unavailable" || statusLoading || statusChanging || loading}>
+                <FiRotateCcw aria-hidden="true" /> {resetting === "results" ? "초기화 중..." : "팀 빌딩 초기화"}
+              </button>
+              <button className={styles.resetBtn} onClick={() => handleResetTeamBuild(true)}
+                disabled={status === "unavailable" || statusLoading || statusChanging || loading}>
+                <FiRotateCcw aria-hidden="true" /> {resetting === "complete" ? "완전 초기화 중..." : "팀 빌딩 완전 초기화"}
+              </button>
+            </div>
           </div>
           <ol className={styles.stepper} aria-label="팀빌딩 진행 과정">
             {statusSteps.map((step, idx) => (

--- a/client/src/pages/adminPages/ManageTeamBuildPage.test.js
+++ b/client/src/pages/adminPages/ManageTeamBuildPage.test.js
@@ -7,6 +7,7 @@ jest.mock("../../api/admin", () => ({
   adminTeamBuildApi: {
     getTeamBuildStatus: jest.fn(),
     resetTeamBuild: jest.fn(),
+    resetTeamBuildCompletely: jest.fn(),
   },
 }));
 
@@ -50,5 +51,40 @@ test("요청 실패 시 기존 단계를 유지하고 다시 시도할 수 있�
   fireEvent.click(await renderReady());
   await waitFor(() => expect(window.alert).toHaveBeenCalledWith("팀 빌딩 초기화에 실패했습니다."));
   expect(screen.getByRole("button", { name: "팀 빌딩 초기화" })).toBeEnabled();
+  expect(screen.getByText("결과").closest("li")).toHaveAttribute("aria-current", "step");
+});
+
+
+test("완전 초기화는 삭제 범위를 안내하고 취소 시 요청하지 않는다", async () => {
+  await renderReady();
+  window.confirm.mockReturnValue(false);
+  fireEvent.click(screen.getByRole("button", { name: "팀 빌딩 완전 초기화" }));
+  expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining("모든 차수의 지원·모집 데이터(희망 지원자 포함)"));
+  expect(adminTeamBuildApi.resetTeamBuildCompletely).not.toHaveBeenCalled();
+  expect(adminTeamBuildApi.resetTeamBuild).not.toHaveBeenCalled();
+});
+
+test("완전 초기화 중 다른 작업을 막고 성공 후 시작 단계로 갱신한다", async () => {
+  let finishReset;
+  adminTeamBuildApi.resetTeamBuildCompletely.mockImplementation(() => new Promise(resolve => { finishReset = resolve; }));
+  await renderReady();
+  fireEvent.click(screen.getByRole("button", { name: "팀 빌딩 완전 초기화" }));
+  expect(screen.getByRole("button", { name: "완전 초기화 중..." })).toBeDisabled();
+  expect(screen.getByRole("button", { name: "팀 빌딩 초기화" })).toBeDisabled();
+  expect(screen.getByRole("button", { name: "지원 CSV 다운로드" })).toBeDisabled();
+  adminTeamBuildApi.getTeamBuildStatus.mockResolvedValue({ status: "OPEN", round: 1, completedRound: 0 });
+  finishReset();
+  await waitFor(() => expect(screen.getByRole("button", { name: "팀 빌딩 완전 초기화" })).toBeEnabled());
+  expect(adminTeamBuildApi.resetTeamBuildCompletely).toHaveBeenCalledTimes(1);
+  expect(adminTeamBuildApi.resetTeamBuild).not.toHaveBeenCalled();
+  expect(screen.getByText("시작").closest("li")).toHaveAttribute("aria-current", "step");
+});
+
+test("완전 초기화 실패 시 결과 단계를 유지하고 재시도할 수 있다", async () => {
+  adminTeamBuildApi.resetTeamBuildCompletely.mockRejectedValue(new Error("failed"));
+  await renderReady();
+  fireEvent.click(screen.getByRole("button", { name: "팀 빌딩 완전 초기화" }));
+  await waitFor(() => expect(window.alert).toHaveBeenCalledWith("팀 빌딩 완전 초기화에 실패했습니다."));
+  expect(screen.getByRole("button", { name: "팀 빌딩 완전 초기화" })).toBeEnabled();
   expect(screen.getByText("결과").closest("li")).toHaveAttribute("aria-current", "step");
 });

--- a/server/src/main/java/wap/web2/server/admin/controller/AdminTeamBuildingController.java
+++ b/server/src/main/java/wap/web2/server/admin/controller/AdminTeamBuildingController.java
@@ -66,6 +66,14 @@ public class AdminTeamBuildingController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/building/reset/current/complete")
+    @Operation(summary = "현재 학기 팀빌딩 완전 초기화",
+        description = "현재 학기의 모든 차수 지원·모집·희망 지원자, 배정 결과와 3차 분류 정보를 삭제한 뒤 시작 단계로 되돌립니다.")
+    public ResponseEntity<Void> resetTeamBuildingCompletely() {
+        adminTeamBuildingService.resetTeamBuildingCompletely();
+        return ResponseEntity.ok().build();
+    }
+
     @GetMapping(value = "/applies/export", produces = "text/csv; charset=UTF-8")
     @Operation(
         summary = "지원 현황 CSV 다운로드",

--- a/server/src/main/java/wap/web2/server/admin/service/AdminTeamBuildingService.java
+++ b/server/src/main/java/wap/web2/server/admin/service/AdminTeamBuildingService.java
@@ -59,6 +59,15 @@ public class AdminTeamBuildingService {
 
     @Transactional
     public void resetTeamBuilding() {
+        resetTeamBuilding(false);
+    }
+
+    @Transactional
+    public void resetTeamBuildingCompletely() {
+        resetTeamBuilding(true);
+    }
+
+    private void resetTeamBuilding(boolean includeSubmissions) {
         String semester = generateSemester();
         TeamBuildingMeta meta = teamBuildingMetaRepository.findBySemesterForUpdate(semester)
             .orElseThrow(() -> new ConflictException("현재 학기의 팀빌딩이 생성되지 않았습니다."));
@@ -67,6 +76,11 @@ public class AdminTeamBuildingService {
         plans.deleteById(semester);
         teamRepository.deleteBySemester(semester);
         clusterRepository.deleteBySemester(semester);
+        if (includeSubmissions) {
+            // Derived deletes remove entities so recruitment wishes cascade with their parent.
+            recruitRepository.deleteBySemester(semester);
+            applyRepository.deleteBySemester(semester);
+        }
         meta.reset();
     }
 

--- a/server/src/main/java/wap/web2/server/teambuild/repository/ProjectApplyRepository.java
+++ b/server/src/main/java/wap/web2/server/teambuild/repository/ProjectApplyRepository.java
@@ -12,6 +12,8 @@ import wap.web2.server.teambuild.entity.ProjectApply;
 
 @Repository
 public interface ProjectApplyRepository extends JpaRepository<ProjectApply, Long> {
+    void deleteBySemester(String semester);
+
     List<ProjectApply> findAllByProject(Project project);
 
     List<ProjectApply> findAllByUserIdAndSemesterAndRound(Long userId, String semester, int round);

--- a/server/src/main/java/wap/web2/server/teambuild/repository/ProjectRecruitRepository.java
+++ b/server/src/main/java/wap/web2/server/teambuild/repository/ProjectRecruitRepository.java
@@ -10,6 +10,8 @@ import wap.web2.server.teambuild.entity.ProjectRecruit;
 
 @Repository
 public interface ProjectRecruitRepository extends JpaRepository<ProjectRecruit, Long> {
+    void deleteBySemester(String semester);
+
     Boolean existsByProjectIdAndSemester(Long projectId, String semester);
 
     boolean existsByProjectIdAndSemesterAndRound(Long projectId, String semester, int round);

--- a/server/src/test/java/wap/web2/server/admin/service/AdminTeamBuildingRoundTest.java
+++ b/server/src/test/java/wap/web2/server/admin/service/AdminTeamBuildingRoundTest.java
@@ -61,6 +61,36 @@ class AdminTeamBuildingRoundTest {
         verifyNoInteractions(teamRepository, clusterRepository, applyRepository, recruitRepository);
     }
 
+    @Test void completeResetDeletesAllCurrentSemesterSubmissionsAndRestarts() {
+        String semester = generateSemester();
+        TeamBuildingMeta meta = new TeamBuildingMeta(3, 3, 1L, semester, TeamBuildingStatus.CLOSED);
+        when(teamBuildingMetaRepository.findBySemesterForUpdate(semester)).thenReturn(Optional.of(meta));
+
+        service.resetTeamBuildingCompletely();
+
+        verify(slots).deleteAllInBatch(any());
+        verify(planTeams).deleteAllInBatch(any());
+        verify(plans).deleteById(semester);
+        verify(teamRepository).deleteBySemester(semester);
+        verify(clusterRepository).deleteBySemester(semester);
+        var order = inOrder(recruitRepository, applyRepository);
+        order.verify(recruitRepository).deleteBySemester(semester);
+        order.verify(applyRepository).deleteBySemester(semester);
+        verifyNoInteractions(projectRepository, teamBuilder);
+        assertThat(meta.getStatus()).isEqualTo(TeamBuildingStatus.OPEN);
+        assertThat(meta.getRound()).isEqualTo(1);
+        assertThat(meta.getCompletedRound()).isZero();
+    }
+
+    @Test void completeResetWithoutTeamBuildingDoesNotDeleteData() {
+        when(teamBuildingMetaRepository.findBySemesterForUpdate(generateSemester())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(service::resetTeamBuildingCompletely).isInstanceOf(ConflictException.class);
+
+        verifyNoInteractions(slots, planTeams, plans, teamRepository, clusterRepository,
+            applyRepository, recruitRepository, projectRepository);
+    }
+
     @Test void secondRoundPreservesExistingMembersAndCannotBeRunTwice() {
         String semester = generateSemester();
         TeamBuildingMeta meta = new TeamBuildingMeta(2, 1, 1L, semester, TeamBuildingStatus.CLOSED);


### PR DESCRIPTION
## 📌 관련 이슈

- 별도 연결 이슈 없음

## ✨ PR 세부 내용

관리자 페이지에 ‘팀 빌딩 완전 초기화’ 버튼을 추가했습니다. 확인 후 현재 학기의 모든 차수 지원·모집·희망 지원자, 배정 결과와 3차 분류 정보를 삭제하고 1차 시작 단계로 돌아갑니다.

- 관리자 전용 완전 초기화 API를 추가하고, 메타데이터 잠금과 단일 트랜잭션으로 처리합니다.
- 기존 초기화 기능은 유지하며 프로젝트 글과 다른 학기 데이터는 보존합니다.
- 삭제 범위 확인, 처리 중 중복 작업 방지, 완료 후 상태 갱신과 실패 시 재시도를 지원합니다.
- 클라이언트 빌드를 막던 RadioButton의 React import를 수정했습니다.

## 👀 확인해주세요!

- 백엔드 관련 테스트 6개, 관리자 화면 테스트 6개 통과
- 서버 bootJar 및 클라이언트 프로덕션 빌드 성공
- Docker 서버 배포 및 실제 데이터 초기화는 실행하지 않았습니다.

## ⌛ 소요 시간

- 별도 측정하지 않음
