### PR TITLE
feat: 배정 완료 팀원의 2차 팀빌딩 참여 차단

### DIFF
--- a/client/src/pages/TeamBuildApplyPage.js
+++ b/client/src/pages/TeamBuildApplyPage.js
@@ -65,6 +65,7 @@ function TeamBuildApplyPage({ round = 1 }) {
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState("");
   const [hasApplied, setHasApplied] = useState(false);
+  const [assigned, setAssigned] = useState(false);
   const [projects, setProjects] = useState([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isNoticeOpen, setIsNoticeOpen] = useState(false);
@@ -114,6 +115,8 @@ function TeamBuildApplyPage({ round = 1 }) {
         if (!active) return;
         const applied = Boolean(status?.hasApplied);
         setHasApplied(applied);
+        setAssigned(Boolean(status?.assigned));
+        if (isSecondRound && status?.assigned) return;
 
         if (!applied) {
           const projectList = await teamBuildApi.getApplyProjects();
@@ -144,7 +147,7 @@ function TeamBuildApplyPage({ round = 1 }) {
     return () => {
       active = false;
     };
-  }, [isPreview]);
+  }, [isPreview, isSecondRound]);
 
   const projectTeamLabels = useMemo(
     () => getProjectTeamLabels(projects),
@@ -309,6 +312,26 @@ function TeamBuildApplyPage({ round = 1 }) {
               다시 시도
             </button>
           </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (isSecondRound && assigned) {
+    return (
+      <div className={styles.page}>
+        <div className={styles.shell}>
+          <section className={styles.myApply}>
+            <h2>이미 팀 배정이 완료되었습니다.</h2>
+            <p>팀 배정이 완료된 팀원은 2차 팀빌딩에 지원할 수 없습니다.</p>
+            <button
+              type="button"
+              className={styles.primaryButton}
+              onClick={() => navigate("/")}
+            >
+              홈으로 이동
+            </button>
+          </section>
         </div>
       </div>
     );

--- a/client/src/pages/TeamBuildApplyPage.test.js
+++ b/client/src/pages/TeamBuildApplyPage.test.js
@@ -8,12 +8,14 @@ jest.mock("js-cookie", () => ({ get: () => "test-token" }));
 jest.mock("../api/team-build", () => ({
   teamBuildApi: {
     submitApply: jest.fn().mockResolvedValue({}),
-    getApplyStatus: async () => ({ hasApplied: false }),
+    getApplyStatus: jest.fn(),
     getApplyProjects: jest.fn(),
   },
 }));
 
 beforeEach(() => {
+  jest.clearAllMocks();
+  teamBuildApi.getApplyStatus.mockResolvedValue({ hasApplied: false, assigned: false });
   teamBuildApi.getApplyProjects.mockResolvedValue([
     {
       projectId: 1,
@@ -307,3 +309,20 @@ test.each([[[]], [["BACKEND"]]])(
     ]);
   },
 );
+
+
+test.each([false, true])("배정된 팀원은 2차 지원 화면에 진입할 수 없다 (지원 여부: %s)", async (hasApplied) => {
+  teamBuildApi.getApplyStatus.mockResolvedValue({ hasApplied, assigned: true });
+  render(<MemoryRouter><TeamBuildApplyPage round={2} /></MemoryRouter>);
+  await screen.findByRole("heading", { name: "이미 팀 배정이 완료되었습니다." });
+  expect(screen.queryByRole("button", { name: "지원서 작성하기" })).toBeNull();
+  expect(screen.queryByRole("button", { name: "최종 제출하기" })).toBeNull();
+  expect(teamBuildApi.getApplyProjects).not.toHaveBeenCalled();
+  expect(teamBuildApi.submitApply).not.toHaveBeenCalled();
+});
+
+test("배정 여부로 1차 지원 화면을 차단하지 않는다", async () => {
+  teamBuildApi.getApplyStatus.mockResolvedValue({ hasApplied: false, assigned: true });
+  await renderApplyPage(1);
+  expect(teamBuildApi.getApplyProjects).toHaveBeenCalledTimes(1);
+});

--- a/server/src/main/java/wap/web2/server/teambuild/controller/TeamBuildingControllerV3.java
+++ b/server/src/main/java/wap/web2/server/teambuild/controller/TeamBuildingControllerV3.java
@@ -55,7 +55,8 @@ public class TeamBuildingControllerV3 {
         @CurrentUser UserPrincipal userPrincipal
     ) {
         boolean hasApplied = applyService.hasAppliedThisSemester(userPrincipal.getId());
-        return ResponseEntity.ok(new ApplyStatusResponse(hasApplied));
+        return ResponseEntity.ok(new ApplyStatusResponse(hasApplied,
+            applyService.isAssignedThisSemester(userPrincipal.getId())));
     }
 
     @GetMapping("/projects")

--- a/server/src/main/java/wap/web2/server/teambuild/dto/response/ApplyStatusResponse.java
+++ b/server/src/main/java/wap/web2/server/teambuild/dto/response/ApplyStatusResponse.java
@@ -10,4 +10,5 @@ import lombok.NoArgsConstructor;
 public class ApplyStatusResponse {
 
     private boolean hasApplied;
+    private boolean assigned;
 }

--- a/server/src/main/java/wap/web2/server/teambuild/repository/TeamRepository.java
+++ b/server/src/main/java/wap/web2/server/teambuild/repository/TeamRepository.java
@@ -11,5 +11,7 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 
     List<Team> findAllByProjectIdAndSemesterAndRoundOrderByIdAsc(Long projectId, String semester, int round);
 
+    boolean existsByMemberIdAndSemester(Long memberId, String semester);
+
     void deleteBySemester(String semester);
 }

--- a/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
+++ b/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
@@ -70,6 +70,9 @@ public class ApplyService {
         // Serialize submissions by the same applicant so concurrent requests cannot exceed five.
         User user = userRepository.findByIdForUpdate(userPrincipal.getId())
             .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다."));
+        if (round == 2 && teamRepository.existsByMemberIdAndSemester(user.getId(), semester)) {
+            throw new ConflictException("이미 팀 배정이 완료되어 2차 팀빌딩에 지원할 수 없습니다.");
+        }
         List<ApplyRequest> applies = request.getApplies();
         List<ProjectApply> existing = applyRepository.findAllByUserIdAndSemesterAndRound(
             user.getId(), semester, round);
@@ -237,6 +240,11 @@ public class ApplyService {
         int round = teamBuildingMetaRepository.findBySemester(generateSemester())
             .map(TeamBuildingMeta::getRound).orElse(1);
         return !applyRepository.findAllByUserIdAndSemesterAndRound(userId, generateSemester(), round).isEmpty();
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isAssignedThisSemester(Long userId) {
+        return teamRepository.existsByMemberIdAndSemester(userId, generateSemester());
     }
 
     private void validateRound(int round) {

--- a/server/src/test/java/wap/web2/server/teambuild/service/ApplicationChoiceTest.java
+++ b/server/src/test/java/wap/web2/server/teambuild/service/ApplicationChoiceTest.java
@@ -31,6 +31,7 @@ class ApplicationChoiceTest {
     @Mock UserRepository userRepository;
     @Mock ProjectRepository projectRepository;
     @Mock ProjectApplyRepository applyRepository;
+    @Mock wap.web2.server.teambuild.repository.TeamRepository teamRepository;
     @InjectMocks ApplyService service;
 
     private UserPrincipal applicant() {

--- a/server/src/test/java/wap/web2/server/teambuild/service/ApplyRoundTest.java
+++ b/server/src/test/java/wap/web2/server/teambuild/service/ApplyRoundTest.java
@@ -85,6 +85,29 @@ class ApplyRoundTest {
         assertThat(captor.getValue().getSemester()).isEqualTo(generateSemester());
     }
 
+    @Test
+    void rejectsAssignedMemberBeforeSavingSecondRoundApplications() {
+        User user = new User();
+        user.setId(1L);
+        when(principal.getId()).thenReturn(1L);
+        when(userRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(user));
+        when(teamRepository.existsByMemberIdAndSemester(1L, generateSemester())).thenReturn(true);
+        status(TeamBuildingStatus.APPLY, 2);
+
+        assertThatThrownBy(() -> service.apply(principal, new ProjectAppliesRequest(List.of(
+            new ProjectAppliesRequest.ApplyRequest(10L, "BACKEND", "comment"))), 2))
+            .isInstanceOf(ConflictException.class)
+            .hasMessage("이미 팀 배정이 완료되어 2차 팀빌딩에 지원할 수 없습니다.");
+        verifyNoInteractions(applyRepository, projectRepository);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void assignmentStatusUsesCurrentSemester(boolean assigned) {
+        when(teamRepository.existsByMemberIdAndSemester(1L, generateSemester())).thenReturn(assigned);
+        assertThat(service.isAssignedThisSemester(1L)).isEqualTo(assigned);
+    }
+
     @ParameterizedTest
     @ValueSource(ints = {1, 2})
     void savesRecruitmentInRequestedRound(int round) {


### PR DESCRIPTION
현재 학기에 이미 팀 배정이 완료된 팀원이 2차 팀빌딩에 다시 지원할 수 있던 문제를 해결합니다.

- 서버에서 현재 학기의 배정 기록을 확인하고, 배정된 팀원의 2차 지원 요청을 차단합니다.
- 지원 상태 API에 배정 여부를 제공하고, 2차 지원 화면에서 지원서 대신 참여 불가 안내를 표시합니다.
- 서버 차단 및 상태 제공, 프런트엔드 화면 제한을 별도 커밋으로 분리했습니다.

검증: 서버 관련 테스트 23개, 프런트엔드 지원 화면 및 인증 테스트 20개 통과.
