### PR TITLE
feat: 모바일 지원서 우선순위 이동 버튼 추가

### DIFF
--- a/client/src/assets/TeamBuildApply.module.css
+++ b/client/src/assets/TeamBuildApply.module.css
@@ -1509,6 +1509,39 @@
   align-items: center;
   gap: 8px;
   flex: 1;
+  overflow-wrap: anywhere;
+}
+
+.applicationOrderControls {
+  display: flex;
+  flex-shrink: 0;
+  gap: 4px;
+}
+
+.applicationOrderButton {
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: 1px solid rgba(169, 205, 246, 0.35);
+  border-radius: 8px;
+  background: transparent;
+  color: #9ed0ff;
+  font-size: 22px;
+  cursor: pointer;
+}
+
+.applicationOrderButton:enabled:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.applicationOrderButton:focus-visible {
+  outline: 2px solid rgba(169, 205, 246, 0.8);
+  outline-offset: 2px;
+}
+
+.applicationOrderButton:disabled {
+  opacity: 0.35;
+  cursor: default;
 }
 
 .myApplicationPriorityNumber {
@@ -2036,6 +2069,9 @@
   }
   .myApplicationItem {
     align-items: center;
+  }
+  .applicationOrderControls {
+    flex-direction: column;
   }
   .myApplicationName {
     align-items: center;

--- a/client/src/assets/TeamBuildApply.module.css
+++ b/client/src/assets/TeamBuildApply.module.css
@@ -1518,6 +1518,18 @@
   gap: 4px;
 }
 
+.orderAnnouncement {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 .applicationOrderButton {
   width: 44px;
   height: 44px;

--- a/client/src/components/ProjectCreation/RadioButton.js
+++ b/client/src/components/ProjectCreation/RadioButton.js
@@ -1,4 +1,4 @@
-import { React } from "react";
+import React from "react";
 import styles from "../../assets/ProjectCreation/RadioButton.module.css"; // CSS 파일 경로 추가
 
 const RadioButton = ({ labelname, name, options, selected, setSelected }) => {

--- a/client/src/pages/TeamBuildApplyPage.js
+++ b/client/src/pages/TeamBuildApplyPage.js
@@ -210,7 +210,23 @@ function TeamBuildApplyPage({ round = 1 }) {
     setCancelTarget(null);
   };
 
+  const moveApplication = (applicationId, direction) => {
+    setProjectApplications((prev) => {
+      const index = prev.findIndex((item) => item.id === applicationId);
+      const targetIndex = index + direction;
+      if (index < 0 || targetIndex < 0 || targetIndex >= prev.length) return prev;
+
+      const next = [...prev];
+      [next[index], next[targetIndex]] = [next[targetIndex], next[index]];
+      return next;
+    });
+  };
+
   const handleApplicationDragStart = (applicationId) => (event) => {
+    if (event.target.closest("button")) {
+      event.preventDefault();
+      return;
+    }
     setApplicationDraggingId(applicationId);
     event.dataTransfer.effectAllowed = "move";
     event.dataTransfer.setData("text/plain", String(applicationId));
@@ -449,7 +465,7 @@ function TeamBuildApplyPage({ round = 1 }) {
                   </span>
                 )}
               </div>
-              <p>지원한 프로젝트를 확인하고, 드래그로 우선순위를 조정하세요</p>
+              <p>위·아래 버튼 또는 드래그로 우선순위를 조정하세요</p>
               <p>최소 {MIN_APPLICATIONS}개의 지원서를 작성해야합니다.</p>
             </div>
           </div>
@@ -527,6 +543,26 @@ function TeamBuildApplyPage({ round = 1 }) {
                         <strong>{application.projectTitle}</strong>
                         <span>·</span>
                         <span>{getPositionLabel(application.position)}</span>
+                      </div>
+                      <div className={styles.applicationOrderControls}>
+                        <button
+                          type="button"
+                          className={styles.applicationOrderButton}
+                          disabled={index === 0}
+                          onClick={() => moveApplication(application.id, -1)}
+                          aria-label={`${application.projectTitle} ${getPositionLabel(application.position)} 우선순위 올리기`}
+                        >
+                          ↑
+                        </button>
+                        <button
+                          type="button"
+                          className={styles.applicationOrderButton}
+                          disabled={index === projectApplications.length - 1}
+                          onClick={() => moveApplication(application.id, 1)}
+                          aria-label={`${application.projectTitle} ${getPositionLabel(application.position)} 우선순위 내리기`}
+                        >
+                          ↓
+                        </button>
                       </div>
                       <button
                         type="button"

--- a/client/src/pages/TeamBuildApplyPage.js
+++ b/client/src/pages/TeamBuildApplyPage.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import Cookies from "../utils/authStorage";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { teamBuildApi } from "../api/team-build";
@@ -78,6 +78,32 @@ function TeamBuildApplyPage({ round = 1 }) {
   const [applicationDragOverPlacement, setApplicationDragOverPlacement] =
     useState("before");
   const [primaryPosition, setPrimaryPosition] = useState("");
+  const buttonPointerStart = useRef(false);
+  const pendingOrderChange = useRef(null);
+  const orderControls = useRef(new Map());
+  const [orderAnnouncement, setOrderAnnouncement] = useState("");
+
+  useEffect(() => {
+    const change = pendingOrderChange.current;
+    if (!change) return;
+    pendingOrderChange.current = null;
+    const index = projectApplications.findIndex((item) => item.id === change.id);
+    if (index < 0) return;
+    const application = projectApplications[index];
+    setOrderAnnouncement(
+      `${application.projectTitle} ${getPositionLabel(application.position)} 지원서가 ${index + 1}순위로 이동했습니다.`,
+    );
+    if (change.restoreFocus) {
+      const controls = orderControls.current.get(change.id);
+      const preferred = controls?.querySelector(
+        `[data-direction="${change.direction}"]`,
+      );
+      const target = preferred?.disabled
+        ? controls.querySelector("button:not(:disabled)")
+        : preferred;
+      target?.focus({ preventScroll: true });
+    }
+  }, [projectApplications]);
 
   useEffect(() => {
     if (isPreview) return;
@@ -210,7 +236,12 @@ function TeamBuildApplyPage({ round = 1 }) {
     setCancelTarget(null);
   };
 
-  const moveApplication = (applicationId, direction) => {
+  const moveApplication = (applicationId, direction, event) => {
+    pendingOrderChange.current = {
+      id: applicationId,
+      direction,
+      restoreFocus: document.activeElement === event.currentTarget,
+    };
     setProjectApplications((prev) => {
       const index = prev.findIndex((item) => item.id === applicationId);
       const targetIndex = index + direction;
@@ -223,7 +254,7 @@ function TeamBuildApplyPage({ round = 1 }) {
   };
 
   const handleApplicationDragStart = (applicationId) => (event) => {
-    if (event.target.closest("button")) {
+    if (buttonPointerStart.current || event.target.closest("button")) {
       event.preventDefault();
       return;
     }
@@ -248,6 +279,8 @@ function TeamBuildApplyPage({ round = 1 }) {
     event.preventDefault();
     if (!applicationDraggingId || applicationDraggingId === targetId) return;
 
+    pendingOrderChange.current = { id: applicationDraggingId };
+
     setProjectApplications((prev) => {
       const applicationById = new Map(
         prev.map((application) => [application.id, application]),
@@ -264,6 +297,7 @@ function TeamBuildApplyPage({ round = 1 }) {
   };
 
   const handleApplicationDragEnd = () => {
+    buttonPointerStart.current = false;
     setApplicationDraggingId(null);
     setApplicationDragOverId(null);
     setApplicationDragOverPlacement("before");
@@ -502,6 +536,14 @@ function TeamBuildApplyPage({ round = 1 }) {
             </section>
           )}
 
+          <p
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className={styles.orderAnnouncement}
+          >
+            {orderAnnouncement}
+          </p>
           {projectApplications.length === 0 ? (
             <div className={styles.emptyApply}>
               <img src={emptyFolder} alt="" className={styles.emptyFolder} />
@@ -529,6 +571,15 @@ function TeamBuildApplyPage({ round = 1 }) {
                           : ""
                       } ${isDropTarget ? styles.dragOver : ""} ${dropPlacementClass}`}
                       draggable
+                      onPointerDownCapture={(event) => {
+                        // Native dragstart targets the draggable card, not the pressed button.
+                        buttonPointerStart.current = Boolean(
+                          event.target.closest("button"),
+                        );
+                      }}
+                      onPointerUp={() => {
+                        buttonPointerStart.current = false;
+                      }}
                       onDragStart={handleApplicationDragStart(application.id)}
                       onDragEnd={handleApplicationDragEnd}
                       onDragOver={handleApplicationDragOver(application.id)}
@@ -544,12 +595,21 @@ function TeamBuildApplyPage({ round = 1 }) {
                         <span>·</span>
                         <span>{getPositionLabel(application.position)}</span>
                       </div>
-                      <div className={styles.applicationOrderControls}>
+                      <div
+                        className={styles.applicationOrderControls}
+                        ref={(node) => {
+                          if (node) orderControls.current.set(application.id, node);
+                          else orderControls.current.delete(application.id);
+                        }}
+                      >
                         <button
                           type="button"
                           className={styles.applicationOrderButton}
                           disabled={index === 0}
-                          onClick={() => moveApplication(application.id, -1)}
+                          data-direction="-1"
+                          onClick={(event) =>
+                            moveApplication(application.id, -1, event)
+                          }
                           aria-label={`${application.projectTitle} ${getPositionLabel(application.position)} 우선순위 올리기`}
                         >
                           ↑
@@ -558,7 +618,10 @@ function TeamBuildApplyPage({ round = 1 }) {
                           type="button"
                           className={styles.applicationOrderButton}
                           disabled={index === projectApplications.length - 1}
-                          onClick={() => moveApplication(application.id, 1)}
+                          data-direction="1"
+                          onClick={(event) =>
+                            moveApplication(application.id, 1, event)
+                          }
                           aria-label={`${application.projectTitle} ${getPositionLabel(application.position)} 우선순위 내리기`}
                         >
                           ↓

--- a/client/src/pages/TeamBuildApplyPage.test.js
+++ b/client/src/pages/TeamBuildApplyPage.test.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { teamBuildApi } from "../api/team-build";
 import TeamBuildApplyPage from "./TeamBuildApplyPage";
@@ -69,6 +70,135 @@ function saveApplication() {
 }
 
 test.each([1, 2])(
+  "%i차 이동 버튼으로 같은 프로젝트의 지원서를 정렬하고 해당 순서로 제출한다",
+  async (round) => {
+    teamBuildApi.submitApply.mockClear();
+    teamBuildApi.getApplyProjects.mockResolvedValueOnce([
+      {
+        projectId: 1,
+        title: "웹 프로젝트",
+        projectType: "WEB",
+        recruitPositions: ["BACKEND", "APP"],
+      },
+    ]);
+    await renderApplyPage(round);
+    const orderButton = (position, direction) =>
+      screen.getByRole("button", {
+        name: `웹 프로젝트 ${position} 우선순위 ${direction}`,
+      });
+    const order = () =>
+      screen
+        .getAllByRole("button", { name: /우선순위 올리기$/ })
+        .map((button) => button.getAttribute("aria-label"));
+
+    openNewApplication();
+    fillApplication({
+      position: "BACKEND",
+      career: "백엔드 경력",
+      message: "백엔드 지원",
+    });
+    saveApplication();
+    expect(orderButton("백엔드", "올리기").disabled).toBe(true);
+    expect(orderButton("백엔드", "내리기").disabled).toBe(true);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "+ 지원서 추가 작성하기" }),
+    );
+    fillApplication({ position: "APP", career: "앱 경력", message: "앱 지원" });
+    saveApplication();
+    expect(orderButton("백엔드", "올리기").disabled).toBe(true);
+    expect(orderButton("앱", "내리기").disabled).toBe(true);
+
+    fireEvent.click(orderButton("백엔드", "내리기"));
+    expect(order()).toEqual([
+      "웹 프로젝트 앱 우선순위 올리기",
+      "웹 프로젝트 백엔드 우선순위 올리기",
+    ]);
+    expect(orderButton("앱", "올리기").disabled).toBe(true);
+    expect(orderButton("백엔드", "내리기").disabled).toBe(true);
+
+    orderButton("백엔드", "올리기").focus();
+    act(() => userEvent.keyboard("{Enter}"));
+    expect(order()).toEqual([
+      "웹 프로젝트 백엔드 우선순위 올리기",
+      "웹 프로젝트 앱 우선순위 올리기",
+    ]);
+    fireEvent.click(orderButton("앱", "올리기"));
+
+    if (round === 1) {
+      fireEvent.change(screen.getByRole("combobox", { name: "주요 직무" }), {
+        target: { value: "BACKEND" },
+      });
+    }
+    fireEvent.click(screen.getByRole("button", { name: "최종 제출하기" }));
+    const confirmation = within(screen.getByRole("alertdialog"));
+    expect(
+      confirmation.getAllByRole("listitem").map((item) => item.textContent),
+    ).toEqual(["1웹 프로젝트·앱", "2웹 프로젝트·백엔드"]);
+    fireEvent.click(
+      confirmation.getByRole("button", { name: "최종 제출하기" }),
+    );
+    await screen.findByRole("heading", { name: "지원이 완료되었습니다." });
+    expect(teamBuildApi.submitApply).toHaveBeenCalledTimes(1);
+    expect(teamBuildApi.submitApply).toHaveBeenCalledWith(
+      {
+        applies: [
+          {
+            projectId: 1,
+            position: "APP",
+            career: "앱 경력",
+            comment: "앱 지원",
+          },
+          {
+            projectId: 1,
+            position: "BACKEND",
+            career: "백엔드 경력",
+            comment: "백엔드 지원",
+          },
+        ],
+      },
+      round,
+    );
+  },
+);
+
+test("기존 드래그로 순위를 바꾸면 이동 버튼의 경계 상태도 갱신된다", async () => {
+  await renderApplyPage(1);
+  for (const position of ["BACKEND", "APP"]) {
+    openNewApplication();
+    fillApplication({ position, message: "지원합니다" });
+    saveApplication();
+  }
+  const first = screen.getByRole("button", {
+    name: "웹 프로젝트 지원 취소",
+  }).parentElement;
+  const second = screen.getByRole("button", {
+    name: "앱 프로젝트 지원 취소",
+  }).parentElement;
+  const dataTransfer = { setData: jest.fn() };
+  fireEvent.dragStart(second, { dataTransfer });
+  fireEvent.dragOver(first, { dataTransfer, clientY: 0 });
+  fireEvent.drop(first, { dataTransfer });
+  fireEvent.dragEnd(second, { dataTransfer });
+  expect(
+    screen
+      .getAllByRole("button", { name: /우선순위 올리기$/ })
+      .map((button) => button.getAttribute("aria-label")),
+  ).toEqual([
+    "앱 프로젝트 앱 우선순위 올리기",
+    "웹 프로젝트 백엔드 우선순위 올리기",
+  ]);
+  expect(
+    screen.getByRole("button", { name: "앱 프로젝트 앱 우선순위 올리기" })
+      .disabled,
+  ).toBe(true);
+  expect(
+    screen.getByRole("button", { name: "웹 프로젝트 백엔드 우선순위 내리기" })
+      .disabled,
+  ).toBe(true);
+});
+
+test.each([1, 2])(
   "%i차 경력 자동 입력과 개별 수정, 자기소개 60자 제한",
   async (round) => {
     await renderApplyPage(round);
@@ -129,9 +259,13 @@ test.each([1, 2])(
       });
       saveApplication();
       if (position === "BACKEND") {
-        expect(screen.queryByRole("button", { name: "최종 제출하기" })).toBeNull();
         expect(
-          screen.getByLabelText("현재 지원서 1개").getAttribute("aria-describedby"),
+          screen.queryByRole("button", { name: "최종 제출하기" }),
+        ).toBeNull();
+        expect(
+          screen
+            .getByLabelText("현재 지원서 1개")
+            .getAttribute("aria-describedby"),
         ).toBe("application-count-hint");
       }
     }
@@ -156,10 +290,7 @@ test.each([1, 2])(
     const confirmation = within(screen.getByRole("alertdialog"));
     expect(
       confirmation.getAllByRole("listitem").map((item) => item.textContent),
-    ).toEqual([
-      "1웹 프로젝트·백엔드",
-      "2앱 프로젝트·앱",
-    ]);
+    ).toEqual(["1웹 프로젝트·백엔드", "2앱 프로젝트·앱"]);
     expect(teamBuildApi.submitApply).not.toHaveBeenCalled();
     fireEvent.click(
       confirmation.getByRole("button", { name: "최종 제출하기" }),

--- a/client/src/pages/TeamBuildApplyPage.test.js
+++ b/client/src/pages/TeamBuildApplyPage.test.js
@@ -119,11 +119,19 @@ test.each([1, 2])(
 
     orderButton("백엔드", "올리기").focus();
     act(() => userEvent.keyboard("{Enter}"));
+    expect(document.activeElement).toBe(orderButton("백엔드", "내리기"));
+    expect(screen.getByRole("status").textContent).toBe(
+      "웹 프로젝트 백엔드 지원서가 1순위로 이동했습니다.",
+    );
     expect(order()).toEqual([
       "웹 프로젝트 백엔드 우선순위 올리기",
       "웹 프로젝트 앱 우선순위 올리기",
     ]);
-    fireEvent.click(orderButton("앱", "올리기"));
+    act(() => userEvent.keyboard("{Enter}"));
+    expect(document.activeElement).toBe(orderButton("백엔드", "올리기"));
+    expect(screen.getByRole("status").textContent).toBe(
+      "웹 프로젝트 백엔드 지원서가 2순위로 이동했습니다.",
+    );
 
     if (round === 1) {
       fireEvent.change(screen.getByRole("combobox", { name: "주요 직무" }), {
@@ -171,15 +179,25 @@ test("기존 드래그로 순위를 바꾸면 이동 버튼의 경계 상태도 
   }
   const first = screen.getByRole("button", {
     name: "웹 프로젝트 지원 취소",
-  }).parentElement;
+  }).closest('[draggable="true"]');
   const second = screen.getByRole("button", {
     name: "앱 프로젝트 지원 취소",
-  }).parentElement;
+  }).closest('[draggable="true"]');
   const dataTransfer = { setData: jest.fn() };
+  fireEvent.pointerDown(
+    screen.getByRole("button", { name: "앱 프로젝트 앱 우선순위 올리기" }),
+  );
+  expect(fireEvent.dragStart(second, { dataTransfer })).toBe(false);
+  expect(dataTransfer.setData).not.toHaveBeenCalled();
+  fireEvent.pointerUp(second);
+  fireEvent.pointerDown(second);
   fireEvent.dragStart(second, { dataTransfer });
   fireEvent.dragOver(first, { dataTransfer, clientY: 0 });
   fireEvent.drop(first, { dataTransfer });
   fireEvent.dragEnd(second, { dataTransfer });
+  expect(screen.getByRole("status").textContent).toBe(
+    "앱 프로젝트 앱 지원서가 1순위로 이동했습니다.",
+  );
   expect(
     screen
       .getAllByRole("button", { name: /우선순위 올리기$/ })
@@ -196,6 +214,17 @@ test("기존 드래그로 순위를 바꾸면 이동 버튼의 경계 상태도 
     screen.getByRole("button", { name: "웹 프로젝트 백엔드 우선순위 내리기" })
       .disabled,
   ).toBe(true);
+  fireEvent.click(
+    screen.getByRole("button", { name: "앱 프로젝트 앱 우선순위 내리기" }),
+  );
+  expect(
+    screen.getAllByRole("button", { name: /우선순위 올리기$/ }).map(
+      (button) => button.getAttribute("aria-label"),
+    ),
+  ).toEqual([
+    "웹 프로젝트 백엔드 우선순위 올리기",
+    "앱 프로젝트 앱 우선순위 올리기",
+  ]);
 });
 
 test.each([1, 2])(


### PR DESCRIPTION
## 📌 관련 이슈

- 연결된 이슈 없음

## ✨ PR 세부 내용

모바일에서 지원서 카드를 드래그하면 스크롤로 이어져 우선순위를 바꾸기 어려웠습니다. 1·2차 지원서에 위·아래 이동 버튼을 추가하여 탭으로 순서를 변경할 수 있게 했습니다.

- 모바일과 PC에 이동 버튼을 표시하며 기존 드래그를 유지합니다. 첫 항목의 올리기와 마지막 항목의 내리기는 비활성화합니다.
- 44×44px 터치 영역, 모바일 세로 배치, 긴 제목 줄바꿈, 접근성 이름과 키보드 포커스 스타일을 적용했습니다.
- 같은 프로젝트의 다른 직무 이동, 경계 상태, 키보드 조작, 드래그 및 최종 제출 순서를 회귀 테스트로 검증합니다.
- 빌드 중 발견한 기존 RadioButton의 잘못된 React named import를 default import로 수정했습니다.

리뷰 후 Chromium에서 버튼에서 시작한 끌기가 부모 카드의 드래그로 이어지고, 키보드로 맨 위·아래에 이동하면 비활성 버튼에서 포커스가 빠지는 문제를 확인했습니다. 포인터 시작 위치로 드래그를 차단하고, 같은 항목의 사용 가능한 이동 버튼으로 포커스를 유지하도록 수정했습니다. 버튼·드래그 이동 후 새 순위를 알리는 라이브 영역도 추가했습니다.

논리적 작업별로 최초 구현 세 커밋과 재현된 문제 수정·회귀 검증 두 커밋으로 분리했습니다. API와 서버 변경은 없습니다.

## 👀 확인해주세요!

- 지원서·인증 테스트 20개 통과: CI=true npm test -- --watchAll=false --runInBand TeamBuildApplyPage --silent
- npm run build 성공
- 로컬 Chromium 모바일 에뮬레이션에서 버튼 탭 정렬, 버튼 시작 드래그 차단, 기존 카드 드래그, 경계 이동 후 키보드 포커스 유지 및 터치 스크롤을 확인했습니다.
- 320·390·640·1280px 화면에서 긴 제목의 가로 넘침이 없음을 확인했습니다.
- 실제 모바일 Safari·Chrome 기기 및 스크린 리더 음성 출력은 추가 확인이 필요합니다.

## ⌛ 소요 시간

- 별도 측정하지 않음
