### PR TITLE
feat: 프로젝트 직무별 모집 인원 및 1차 지원 직무 제한

### DIFF
--- a/client/src/assets/ProjectCreation/ProjectForm.module.css
+++ b/client/src/assets/ProjectCreation/ProjectForm.module.css
@@ -193,3 +193,45 @@
   z-index: 1; /* 텍스트가 이미지보다 위에 표시되도록 */
   font-family: "Pretendard-Regular";
 }
+
+.recruitment {
+  margin: 24px 0;
+  color: #ebebeb;
+  text-align: left;
+}
+
+.recruitment p {
+  color: #b5b5b5;
+  font-size: 14px;
+}
+
+.recruitment_row {
+  display: flex;
+  align-items: end;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.recruitment_row label {
+  flex: 1;
+  min-width: 0;
+  font-size: 13px;
+}
+
+.recruitment_row input {
+  box-sizing: border-box;
+  width: 100%;
+  margin-top: 6px;
+  padding: 8px;
+  border: 1px solid #666;
+  border-radius: 4px;
+  background: #1f1f1f;
+  color: #ebebeb;
+}
+
+.recruitment button {
+  padding: 8px;
+  border: 0;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/client/src/components/ProjectCreation/ProjectFormNew.js
+++ b/client/src/components/ProjectCreation/ProjectFormNew.js
@@ -1,4 +1,8 @@
-import { MAX_PROJECT_TITLE_LENGTH, MAX_PROJECT_SUMMARY_LENGTH, MAX_PROJECT_CONTENT_LENGTH } from "../../constants/project";
+import {
+  MAX_PROJECT_TITLE_LENGTH,
+  MAX_PROJECT_SUMMARY_LENGTH,
+  MAX_PROJECT_CONTENT_LENGTH,
+} from "../../constants/project";
 import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 
@@ -11,6 +15,9 @@ import TextInputForm from "./TextInputForm";
 import TechStackSelector from "./TechStackSelector";
 import TeamMemberInputForm from "./TeamMemberInputForm";
 import InputPin from "./InputPin";
+import RecruitmentPositionInput, {
+  recruitmentPositionsError,
+} from "./RecruitmentPositionInput";
 
 // 사용성을 높인 버전의 프로젝트 생성 폼
 
@@ -40,6 +47,7 @@ const ProjectFormNew = ({ isEdit = false, existingProject = null }) => {
   const { projectId } = useParams();
   const maxImageCount = 4; // 최대 이미지 업로드 개수
   const navigate = useNavigate(); // navigate 함수
+  const [recruitmentPositions, setRecruitmentPositions] = useState([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSemesterLoading, setIsSemesterLoading] = useState(!isEdit);
   const [semesterError, setSemesterError] = useState("");
@@ -120,6 +128,7 @@ const ProjectFormNew = ({ isEdit = false, existingProject = null }) => {
   // 기존 데이터 초기화
   useEffect(() => {
     if (isEdit && existingProject) {
+      setRecruitmentPositions(existingProject.recruitmentPositions || []);
       setThumbnail(existingProject.thumbnail || null);
       setSemester(existingProject.semester || "");
       setProjectType(existingProject.projectType || "");
@@ -154,10 +163,20 @@ const ProjectFormNew = ({ isEdit = false, existingProject = null }) => {
       return;
     }
 
+    const recruitmentError = recruitmentPositionsError(recruitmentPositions);
+    if (recruitmentError) {
+      alert(recruitmentError);
+      return;
+    }
+
     setIsSubmitting(true);
 
     const formData = new FormData();
     const projectData = {
+      recruitmentPositions: recruitmentPositions.map(({ role, count }) => ({
+        role: role.trim(),
+        count: Number(count),
+      })),
       title,
       projectType,
       content,
@@ -308,6 +327,10 @@ const ProjectFormNew = ({ isEdit = false, existingProject = null }) => {
           ))}
         </div>
 
+        <RecruitmentPositionInput
+          positions={recruitmentPositions}
+          onChange={setRecruitmentPositions}
+        />
         <TechStackSelector
           selectedTechStacks={selectedTechStacks}
           toggleTechStack={toggleTechStack}

--- a/client/src/components/ProjectCreation/ProjectFormNew.test.js
+++ b/client/src/components/ProjectCreation/ProjectFormNew.test.js
@@ -1,0 +1,147 @@
+import React from "react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { projectApi } from "../../api/project";
+import ProjectFormNew from "./ProjectFormNew";
+
+jest.mock("../../api/project", () => ({
+  projectApi: {
+    getCurrentSemester: jest.fn(),
+    createProject: jest.fn(),
+    updateProject: jest.fn(),
+  },
+}));
+jest.mock("./ImageUploader", () => () => null);
+jest.mock("./TechStackSelector", () => () => null);
+jest.mock("./TeamMemberInputForm", () => () => null);
+jest.mock("./InputPin", () => ({ password, setPassword }) => (
+  <input
+    aria-label="비밀번호"
+    value={password}
+    onChange={(event) => setPassword(event.target.value)}
+  />
+));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(window, "alert").mockImplementation(() => {});
+  projectApi.getCurrentSemester.mockResolvedValue({ semester: "2026-02" });
+  projectApi.createProject.mockResolvedValue({});
+  projectApi.updateProject.mockResolvedValue({});
+});
+afterEach(() => jest.restoreAllMocks());
+
+const readProject = (data) =>
+  new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(JSON.parse(reader.result));
+    reader.readAsText(data.get("project"));
+  });
+
+test("모집 직무를 추가하고 인원을 숫자로 저장한다", async () => {
+  render(
+    <MemoryRouter>
+      <ProjectFormNew />
+    </MemoryRouter>,
+  );
+  await screen.findByText("2026년 2학기");
+  fireEvent.click(screen.getByRole("button", { name: "모집 직무 추가" }));
+  fireEvent.change(screen.getByLabelText("직무 1"), {
+    target: { value: " 프론트엔드 " },
+  });
+  fireEvent.change(screen.getByLabelText("모집 인원 1 (명)"), {
+    target: { value: "3" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "모집 직무 추가" }));
+  fireEvent.change(screen.getByLabelText("직무 2"), {
+    target: { value: "백엔드" },
+  });
+  fireEvent.change(screen.getByLabelText("모집 인원 2 (명)"), {
+    target: { value: "2" },
+  });
+  fireEvent.change(screen.getByLabelText("비밀번호"), {
+    target: { value: "pw" },
+  });
+  await act(async () => {
+    fireEvent.submit(
+      screen.getByRole("button", { name: "프로젝트 생성" }).closest("form"),
+    );
+  });
+  await waitFor(() =>
+    expect(projectApi.createProject).toHaveBeenCalledTimes(1),
+  );
+  expect(
+    (await readProject(projectApi.createProject.mock.calls[0][0]))
+      .recruitmentPositions,
+  ).toEqual([
+    { role: "프론트엔드", count: 3 },
+    { role: "백엔드", count: 2 },
+  ]);
+});
+
+test("수정 화면에서 기존 모집 정보를 불러오고 모두 삭제할 수 있다", async () => {
+  render(
+    <MemoryRouter>
+      <ProjectFormNew
+        isEdit
+        existingProject={{
+          semester: "2026-02",
+          recruitmentPositions: [{ role: "백엔드", count: 2 }],
+        }}
+      />
+    </MemoryRouter>,
+  );
+  expect(screen.getByLabelText("직무 1").value).toBe("백엔드");
+  expect(screen.getByLabelText("모집 인원 1 (명)").value).toBe("2");
+  fireEvent.click(screen.getByRole("button", { name: "모집 직무 1 삭제" }));
+  fireEvent.change(screen.getByLabelText("비밀번호"), {
+    target: { value: "pw" },
+  });
+  await act(async () => {
+    fireEvent.submit(
+      screen.getByRole("button", { name: "프로젝트 수정" }).closest("form"),
+    );
+  });
+  await waitFor(() =>
+    expect(projectApi.updateProject).toHaveBeenCalledTimes(1),
+  );
+  expect(
+    (await readProject(projectApi.updateProject.mock.calls[0][1]))
+      .recruitmentPositions,
+  ).toEqual([]);
+});
+
+test.each([0, -1, 1.5, ""])(
+  "잘못된 모집 인원 %s로는 요청하지 않는다",
+  async (count) => {
+    render(
+      <MemoryRouter>
+        <ProjectFormNew />
+      </MemoryRouter>,
+    );
+    await screen.findByText("2026년 2학기");
+    fireEvent.click(screen.getByRole("button", { name: "모집 직무 추가" }));
+    fireEvent.change(screen.getByLabelText("직무 1"), {
+      target: { value: "백엔드" },
+    });
+    fireEvent.change(screen.getByLabelText("모집 인원 1 (명)"), {
+      target: { value: count },
+    });
+    fireEvent.change(screen.getByLabelText("비밀번호"), {
+      target: { value: "pw" },
+    });
+    fireEvent.submit(
+      screen.getByRole("button", { name: "프로젝트 생성" }).closest("form"),
+    );
+    expect(projectApi.createProject).not.toHaveBeenCalled();
+    expect(window.alert).toHaveBeenCalledWith(
+      "모집 인원은 1 이상의 정수로 입력해 주세요.",
+    );
+  },
+);

--- a/client/src/components/ProjectCreation/RadioButton.js
+++ b/client/src/components/ProjectCreation/RadioButton.js
@@ -1,4 +1,4 @@
-import { React } from "react";
+import React from "react";
 import styles from "../../assets/ProjectCreation/RadioButton.module.css"; // CSS 파일 경로 추가
 
 const RadioButton = ({ labelname, name, options, selected, setSelected }) => {

--- a/client/src/components/ProjectCreation/RecruitmentPositionInput.js
+++ b/client/src/components/ProjectCreation/RecruitmentPositionInput.js
@@ -1,0 +1,79 @@
+import React from "react";
+import styles from "../../assets/ProjectCreation/ProjectForm.module.css";
+
+export const recruitmentPositionsError = (positions) => {
+  const roles = positions.map(({ role }) => role.trim());
+  if (roles.some((role) => !role || role.length > 50)) {
+    return "모집 직무는 1~50자로 입력해 주세요.";
+  }
+  if (new Set(roles).size !== roles.length) {
+    return "모집 직무가 중복되었습니다.";
+  }
+  if (
+    positions.some(
+      ({ count }) =>
+        !Number.isInteger(Number(count)) ||
+        Number(count) < 1 ||
+        Number(count) > 2147483647,
+    )
+  ) {
+    return "모집 인원은 1 이상의 정수로 입력해 주세요.";
+  }
+  return "";
+};
+
+export default function RecruitmentPositionInput({ positions, onChange }) {
+  const update = (index, field, value) => {
+    onChange(
+      positions.map((position, i) =>
+        i === index ? { ...position, [field]: value } : position,
+      ),
+    );
+  };
+
+  return (
+    <section className={styles.recruitment} aria-label="직무별 모집 인원">
+      <h3>직무별 모집 인원</h3>
+      <p>모집할 직무와 인원을 추가해 주세요. (선택)</p>
+      {positions.map((position, index) => (
+        <div className={styles.recruitment_row} key={index}>
+          <label>
+            직무 {index + 1}
+            <input
+              value={position.role}
+              placeholder="예: 프론트엔드"
+              maxLength={50}
+              required
+              onChange={(event) => update(index, "role", event.target.value)}
+            />
+          </label>
+          <label>
+            모집 인원 {index + 1} (명)
+            <input
+              type="number"
+              min="1"
+              max="2147483647"
+              step="1"
+              required
+              value={position.count}
+              onChange={(event) => update(index, "count", event.target.value)}
+            />
+          </label>
+          <button
+            type="button"
+            aria-label={`모집 직무 ${index + 1} 삭제`}
+            onClick={() => onChange(positions.filter((_, i) => i !== index))}
+          >
+            삭제
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={() => onChange([...positions, { role: "", count: 1 }])}
+      >
+        모집 직무 추가
+      </button>
+    </section>
+  );
+}

--- a/client/src/components/ProjectDetail/ProjectDetailForm.js
+++ b/client/src/components/ProjectDetail/ProjectDetailForm.js
@@ -118,6 +118,19 @@ const ProjectDetailForm = () => {
         </div>
       </div>
 
+      <section aria-label="직무별 모집 인원">
+        <h3>직무별 모집 인원</h3>
+        {projectData.recruitmentPositions?.length > 0 ? (
+          <p>
+            {projectData.recruitmentPositions
+              .map(({ role, count }) => `${role} ${count}명`)
+              .join(", ")}
+          </p>
+        ) : (
+          <p>등록된 모집 인원 정보가 없습니다.</p>
+        )}
+      </section>
+
       {/* 이미지 섹션 */}
       <div className={styles.images}>
         {projectData.images && projectData.images.length > 0 ? (

--- a/client/src/components/ProjectDetail/ProjectDetailForm.test.js
+++ b/client/src/components/ProjectDetail/ProjectDetailForm.test.js
@@ -115,3 +115,22 @@ test("버튼 표시 후 서버가 수정 권한을 거절하면 이동하지 않
   );
   expect(screen.queryByText("Edit page")).toBeNull();
 });
+
+test("상세 화면에 직무별 모집 인원을 표시한다", async () => {
+  projectApi.getProjectDetail.mockResolvedValue({
+    title: "Project title",
+    recruitmentPositions: [
+      { role: "프론트엔드", count: 3 },
+      { role: "백엔드", count: 2 },
+    ],
+  });
+  openPage(ProjectDetailForm);
+  expect(await screen.findByText("프론트엔드 3명, 백엔드 2명")).toBeTruthy();
+});
+
+test("기존 게시글에는 모집 정보가 없음을 표시한다", async () => {
+  openPage(ProjectDetailForm);
+  expect(
+    await screen.findByText("등록된 모집 인원 정보가 없습니다."),
+  ).toBeTruthy();
+});

--- a/client/src/components/TeamBuild/ProjectApplicationModal.js
+++ b/client/src/components/TeamBuild/ProjectApplicationModal.js
@@ -23,7 +23,7 @@ export default function ProjectApplicationModal({
   );
 
   const handleSave = () => {
-    if (!projectFormPosition) {
+    if (!project.recruitPositions.includes(projectFormPosition)) {
       alert("지원 직무를 선택해주세요.");
       return;
     }
@@ -67,6 +67,9 @@ export default function ProjectApplicationModal({
         <p className={styles.applicationModalDescription}>
           이 지원서로 {project.title}에 지원하게 됩니다.
         </p>
+        {project.recruitPositions.length === 0 && (
+          <p role="status">등록된 모집 직무가 없어 지원할 수 없습니다.</p>
+        )}
         <div className={styles.formGroup}>
           <label htmlFor="projectPosition">지원 직무</label>
           <select
@@ -96,7 +99,8 @@ export default function ProjectApplicationModal({
             className={styles.applicationModalDescription}
           >
             저장한 경력은 새 지원서에 자동 입력되며, 지원서마다 수정할 수
-            있습니다.<br />
+            있습니다.
+            <br />
             없다면 '없음'이라고 작성해주세요
           </p>
         </div>
@@ -121,6 +125,7 @@ export default function ProjectApplicationModal({
           type="button"
           className={styles.modalSubmit}
           onClick={handleSave}
+          disabled={project.recruitPositions.length === 0}
         >
           지원서 저장하기
         </button>

--- a/client/src/pages/TeamBuildApplyPage.js
+++ b/client/src/pages/TeamBuildApplyPage.js
@@ -59,7 +59,8 @@ const reorderProjectIds = (
 function TeamBuildApplyPage({ round = 1 }) {
   const [searchParams] = useSearchParams();
   const isPreview =
-    process.env.NODE_ENV === "development" && searchParams.get("preview") === "1";
+    process.env.NODE_ENV === "development" &&
+    searchParams.get("preview") === "1";
   const isSecondRound = round === 2;
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(true);
@@ -94,9 +95,33 @@ function TeamBuildApplyPage({ round = 1 }) {
     const fetchData = async () => {
       if (isPreview) {
         setProjects([
-          { projectId: 1, title: "캠퍼스 모임 찾기", projectType: "WEB", summary: "관심사가 같은 학우들과 모임을 만드는 웹 서비스", recruitPositions: [...POSITIONS], recruitCount: 4, requirements: "함께 배우며 꾸준히 참여할 팀원을 찾습니다." },
-          { projectId: 2, title: "나의 하루 기록", projectType: "APP", summary: "일상과 목표를 기록하는 모바일 앱", recruitPositions: [...POSITIONS], recruitCount: 3, requirements: "앱 개발에 관심 있는 분을 환영합니다." },
-          { projectId: 3, title: "작은 숲의 모험", projectType: "GAME", summary: "숲을 탐험하며 퍼즐을 해결하는 게임", recruitPositions: [...POSITIONS], recruitCount: 4, requirements: "게임 제작을 함께 경험할 팀원을 찾습니다." },
+          {
+            projectId: 1,
+            title: "캠퍼스 모임 찾기",
+            projectType: "WEB",
+            summary: "관심사가 같은 학우들과 모임을 만드는 웹 서비스",
+            recruitPositions: [...POSITIONS],
+            recruitCount: 4,
+            requirements: "함께 배우며 꾸준히 참여할 팀원을 찾습니다.",
+          },
+          {
+            projectId: 2,
+            title: "나의 하루 기록",
+            projectType: "APP",
+            summary: "일상과 목표를 기록하는 모바일 앱",
+            recruitPositions: [...POSITIONS],
+            recruitCount: 3,
+            requirements: "앱 개발에 관심 있는 분을 환영합니다.",
+          },
+          {
+            projectId: 3,
+            title: "작은 숲의 모험",
+            projectType: "GAME",
+            summary: "숲을 탐험하며 퍼즐을 해결하는 게임",
+            recruitPositions: [...POSITIONS],
+            recruitCount: 4,
+            requirements: "게임 제작을 함께 경험할 팀원을 찾습니다.",
+          },
         ]);
         setHasApplied(false);
         setIsLoading(false);
@@ -122,10 +147,13 @@ function TeamBuildApplyPage({ round = 1 }) {
             Array.isArray(projectList)
               ? projectList.map((project) => ({
                   ...project,
-                  // 현재 프로젝트 API는 모집 직무를 생략하므로 전체 직무를 기본값으로 사용한다.
-                  recruitPositions: Array.isArray(project.recruitPositions)
-                    ? project.recruitPositions
-                    : [...POSITIONS],
+                  recruitPositions: !isSecondRound
+                    ? Array.isArray(project.firstRoundRecruitPositions)
+                      ? project.firstRoundRecruitPositions
+                      : []
+                    : Array.isArray(project.recruitPositions)
+                      ? project.recruitPositions
+                      : [...POSITIONS],
                 }))
               : [],
           );
@@ -144,7 +172,7 @@ function TeamBuildApplyPage({ round = 1 }) {
     return () => {
       active = false;
     };
-  }, [isPreview]);
+  }, [isPreview, isSecondRound]);
 
   const projectTeamLabels = useMemo(
     () => getProjectTeamLabels(projects),
@@ -445,8 +473,7 @@ function TeamBuildApplyPage({ round = 1 }) {
                   <span
                     id="application-count-hint"
                     className={styles.applicationCountHint}
-                  >
-                  </span>
+                  ></span>
                 )}
               </div>
               <p>지원한 프로젝트를 확인하고, 드래그로 우선순위를 조정하세요</p>

--- a/client/src/pages/TeamBuildApplyPage.test.js
+++ b/client/src/pages/TeamBuildApplyPage.test.js
@@ -20,18 +20,21 @@ beforeEach(() => {
       title: "웹 프로젝트",
       projectType: "WEB",
       recruitPositions: ["BACKEND"],
+      firstRoundRecruitPositions: ["BACKEND"],
     },
     {
       projectId: 2,
       title: "앱 프로젝트",
       projectType: "APP",
       recruitPositions: ["APP"],
+      firstRoundRecruitPositions: ["APP"],
     },
     {
       projectId: 3,
       title: "게임 프로젝트",
       projectType: "GAME",
       recruitPositions: ["GAME"],
+      firstRoundRecruitPositions: ["GAME"],
     },
   ]);
 });
@@ -129,9 +132,13 @@ test.each([1, 2])(
       });
       saveApplication();
       if (position === "BACKEND") {
-        expect(screen.queryByRole("button", { name: "최종 제출하기" })).toBeNull();
         expect(
-          screen.getByLabelText("현재 지원서 1개").getAttribute("aria-describedby"),
+          screen.queryByRole("button", { name: "최종 제출하기" }),
+        ).toBeNull();
+        expect(
+          screen
+            .getByLabelText("현재 지원서 1개")
+            .getAttribute("aria-describedby"),
         ).toBe("application-count-hint");
       }
     }
@@ -156,10 +163,7 @@ test.each([1, 2])(
     const confirmation = within(screen.getByRole("alertdialog"));
     expect(
       confirmation.getAllByRole("listitem").map((item) => item.textContent),
-    ).toEqual([
-      "1웹 프로젝트·백엔드",
-      "2앱 프로젝트·앱",
-    ]);
+    ).toEqual(["1웹 프로젝트·백엔드", "2앱 프로젝트·앱"]);
     expect(teamBuildApi.submitApply).not.toHaveBeenCalled();
     fireEvent.click(
       confirmation.getByRole("button", { name: "최종 제출하기" }),
@@ -242,11 +246,8 @@ test.each([1, 2])(
 );
 
 test.each([
-  [1, undefined],
   [2, undefined],
-  [1, null],
   [2, null],
-  [1, "BACKEND"],
   [2, "BACKEND"],
 ])(
   "%i차 프로젝트의 직무 목록 %s를 기본 직무로 보완하고 지원서를 저장한다",
@@ -295,7 +296,7 @@ test.each([[[]], [["BACKEND"]]])(
         projectId: 10,
         title: "직무 지정 프로젝트",
         projectType: "WEB",
-        recruitPositions,
+        firstRoundRecruitPositions: recruitPositions,
       },
     ]);
     await renderApplyPage(1);
@@ -307,3 +308,45 @@ test.each([[[]], [["BACKEND"]]])(
     ]);
   },
 );
+
+test.each([undefined, null, "BACKEND", []])(
+  "1차에서 모집 직무 정보 %j가 없으면 지원을 막는다",
+  async (firstRoundRecruitPositions) => {
+    teamBuildApi.getApplyProjects.mockResolvedValueOnce([
+      { projectId: 10, title: "모집 미등록", firstRoundRecruitPositions },
+    ]);
+    await renderApplyPage(1);
+    openNewApplication();
+    const form = within(screen.getByRole("dialog"));
+    expect(form.getAllByRole("option").map((option) => option.value)).toEqual([
+      "",
+    ]);
+    expect(form.getByRole("button", { name: "지원서 저장하기" }).disabled).toBe(
+      true,
+    );
+    expect(
+      form.getByText("등록된 모집 직무가 없어 지원할 수 없습니다."),
+    ).toBeTruthy();
+  },
+);
+
+test("1차 지원에는 서버가 게시글에서 계산한 모집 직무만 표시한다", async () => {
+  teamBuildApi.getApplyProjects.mockResolvedValueOnce([
+    {
+      projectId: 10,
+      title: "백엔드 모집",
+      firstRoundRecruitPositions: ["BACKEND"],
+      recruitPositions: ["FRONTEND", "BACKEND"],
+    },
+  ]);
+  await renderApplyPage(1);
+  openNewApplication();
+  const form = within(screen.getByRole("dialog"));
+  expect(form.getAllByRole("option").map((option) => option.value)).toEqual([
+    "",
+    "BACKEND",
+  ]);
+  fillApplication({ position: "BACKEND", message: "함께 개발하고 싶습니다" });
+  saveApplication();
+  expect(screen.getByLabelText("현재 지원서 1개")).toBeTruthy();
+});

--- a/server/src/main/java/wap/web2/server/project/controller/ProjectController.java
+++ b/server/src/main/java/wap/web2/server/project/controller/ProjectController.java
@@ -77,6 +77,7 @@ public class ProjectController {
     ) throws IOException {
         // RequestPart 중 ContentType 형식이 서로 다른 file 2종류를 ProjectCreateRequest 에 할당하여 새로운 RequestDto 객체 생성
         ProjectRequest fullRequest = ProjectRequest.builder()
+            .recruitmentPositions(request.getRecruitmentPositions())
             .title(request.getTitle())
             .projectType(request.getProjectType())
             .content(request.getContent())

--- a/server/src/main/java/wap/web2/server/project/dto/RecruitmentPositionDto.java
+++ b/server/src/main/java/wap/web2/server/project/dto/RecruitmentPositionDto.java
@@ -1,0 +1,57 @@
+package wap.web2.server.project.dto;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import wap.web2.server.exception.BadRequestException;
+import wap.web2.server.project.entity.RecruitmentPosition;
+
+public record RecruitmentPositionDto(
+    String role,
+    @JsonDeserialize(using = HeadcountDeserializer.class) Integer count
+) {
+
+    public static class HeadcountDeserializer extends JsonDeserializer<Integer> {
+        @Override
+        public Integer deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+            if (!parser.hasToken(JsonToken.VALUE_NUMBER_INT)) {
+                return (Integer) context.handleUnexpectedToken(Integer.class, parser);
+            }
+            return parser.getIntValue();
+        }
+    }
+
+    public static RecruitmentPositionDto from(RecruitmentPosition position) {
+        return new RecruitmentPositionDto(position.getRole(), position.getCount());
+    }
+
+    public static List<RecruitmentPosition> toEntities(List<RecruitmentPositionDto> positions) {
+        List<RecruitmentPosition> result = new ArrayList<>();
+        if (positions == null) {
+            return result;
+        }
+        Set<String> roles = new HashSet<>();
+        for (RecruitmentPositionDto position : positions) {
+            if (position == null || position.role() == null || position.role().isBlank()
+                || position.role().strip().length() > 50) {
+                throw new BadRequestException("모집 직무는 1~50자로 입력해 주세요.");
+            }
+            String role = position.role().strip();
+            if (!roles.add(role)) {
+                throw new BadRequestException("모집 직무가 중복되었습니다.");
+            }
+            if (position.count() == null || position.count() < 1) {
+                throw new BadRequestException("모집 인원은 1 이상의 정수로 입력해 주세요.");
+            }
+            result.add(new RecruitmentPosition(role, position.count()));
+        }
+        return result;
+    }
+}

--- a/server/src/main/java/wap/web2/server/project/dto/request/ProjectRequest.java
+++ b/server/src/main/java/wap/web2/server/project/dto/request/ProjectRequest.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.springframework.web.multipart.MultipartFile;
 import wap.web2.server.member.entity.User;
+import wap.web2.server.project.dto.RecruitmentPositionDto;
 import wap.web2.server.project.dto.ImageDto;
 import wap.web2.server.project.dto.TeamMemberDto;
 import wap.web2.server.project.dto.TechStackDto;
@@ -26,6 +27,7 @@ import wap.web2.server.project.entity.TechStack;
 @AllArgsConstructor
 public class ProjectRequest {
 
+    private List<RecruitmentPositionDto> recruitmentPositions;
     private String title;
     private String projectType;
     private String content;
@@ -73,6 +75,7 @@ public class ProjectRequest {
         }
 
         return Project.builder()
+            .recruitmentPositions(RecruitmentPositionDto.toEntities(request.getRecruitmentPositions()))
             .user(user)
             .title(request.getTitle())
             .projectType(request.getProjectType())

--- a/server/src/main/java/wap/web2/server/project/dto/response/ProjectDetailsResponse.java
+++ b/server/src/main/java/wap/web2/server/project/dto/response/ProjectDetailsResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import wap.web2.server.comment.dto.CommentDto;
 import wap.web2.server.project.dto.ImageDto;
+import wap.web2.server.project.dto.RecruitmentPositionDto;
 import wap.web2.server.project.dto.TeamMemberDto;
 import wap.web2.server.project.dto.TechStackDto;
 import wap.web2.server.project.entity.Project;
@@ -16,6 +17,7 @@ import wap.web2.server.project.entity.Project;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProjectDetailsResponse {
 
+    private List<RecruitmentPositionDto> recruitmentPositions;
     private Long projectId;
     private String title;
     private String projectType;
@@ -45,6 +47,7 @@ public class ProjectDetailsResponse {
         List<CommentDto> comments = project.getComments().stream().map(CommentDto::from).toList();
 
         return ProjectDetailsResponse.builder()
+            .recruitmentPositions(project.getRecruitmentPositions().stream().map(RecruitmentPositionDto::from).toList())
             .projectId(project.getProjectId())
             .title(project.getTitle())
             .projectType(project.getProjectType())

--- a/server/src/main/java/wap/web2/server/project/dto/response/ProjectUpdateDetailsResponse.java
+++ b/server/src/main/java/wap/web2/server/project/dto/response/ProjectUpdateDetailsResponse.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import wap.web2.server.comment.dto.CommentDto;
+import wap.web2.server.project.dto.RecruitmentPositionDto;
 import wap.web2.server.project.dto.TeamMemberDto;
 import wap.web2.server.project.entity.Project;
 
@@ -13,6 +14,7 @@ import wap.web2.server.project.entity.Project;
 @Getter
 public class ProjectUpdateDetailsResponse {
 
+    private List<RecruitmentPositionDto> recruitmentPositions;
     private Long projectId;
     private String title;
     private String projectType;
@@ -31,6 +33,7 @@ public class ProjectUpdateDetailsResponse {
         List<CommentDto> comments = project.getComments().stream().map(CommentDto::from).toList();
 
         return ProjectUpdateDetailsResponse.builder()
+            .recruitmentPositions(project.getRecruitmentPositions().stream().map(RecruitmentPositionDto::from).toList())
             .projectId(project.getProjectId())
             .title(project.getTitle())
             .projectType(project.getProjectType())

--- a/server/src/main/java/wap/web2/server/project/entity/Project.java
+++ b/server/src/main/java/wap/web2/server/project/entity/Project.java
@@ -1,5 +1,8 @@
 package wap.web2.server.project.entity;
 
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.OrderColumn;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -23,6 +26,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import wap.web2.server.comment.entity.Comment;
 import wap.web2.server.member.entity.User;
+import wap.web2.server.project.dto.RecruitmentPositionDto;
 import wap.web2.server.project.dto.TeamMemberDto;
 import wap.web2.server.project.dto.TechStackDto;
 import wap.web2.server.project.dto.request.ProjectRequest;
@@ -73,11 +77,24 @@ public class Project {
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
     List<TechStack> techStacks = new ArrayList<>();
 
+    @Builder.Default
+    @ElementCollection
+    @CollectionTable(name = "project_recruitment_position", joinColumns = @JoinColumn(name = "project_id"))
+    @OrderColumn(name = "position_order")
+    private List<RecruitmentPosition> recruitmentPositions = new ArrayList<>();
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user; // Owner
 
     public void update(ProjectRequest request) {
+        // 필드가 생략된 기존 클라이언트 요청은 모집 정보를 유지한다.
+        if (request.getRecruitmentPositions() != null) {
+            List<RecruitmentPosition> positions = RecruitmentPositionDto.toEntities(request.getRecruitmentPositions());
+            this.recruitmentPositions.clear();
+            this.recruitmentPositions.addAll(positions);
+        }
+
         // 기본 필드 업데이트
         this.title = request.getTitle();
         this.projectType = request.getProjectType();

--- a/server/src/main/java/wap/web2/server/project/entity/RecruitmentPosition.java
+++ b/server/src/main/java/wap/web2/server/project/entity/RecruitmentPosition.java
@@ -1,0 +1,20 @@
+package wap.web2.server.project.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecruitmentPosition {
+
+    @Column(name = "role", nullable = false, length = 50)
+    private String role;
+
+    @Column(name = "headcount", nullable = false)
+    private Integer count;
+}

--- a/server/src/main/java/wap/web2/server/project/service/ProjectService.java
+++ b/server/src/main/java/wap/web2/server/project/service/ProjectService.java
@@ -113,6 +113,7 @@ public class ProjectService {
             .toList();
     }
 
+    @Transactional(readOnly = true)
     public List<ProjectTemplate> getCurrentProjectRecruits() {
         return projectRepository
             .findProjectsBySemester(generateSemester())

--- a/server/src/main/java/wap/web2/server/project/service/ProjectService.java
+++ b/server/src/main/java/wap/web2/server/project/service/ProjectService.java
@@ -23,6 +23,7 @@ import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.member.entity.Role;
 import wap.web2.server.member.entity.User;
 import wap.web2.server.member.repository.UserRepository;
+import wap.web2.server.project.dto.RecruitmentPositionDto;
 import wap.web2.server.project.dto.request.ProjectRequest;
 import wap.web2.server.project.dto.response.ProjectDetailsResponse;
 import wap.web2.server.project.dto.response.ProjectInfoResponse;
@@ -58,6 +59,7 @@ public class ProjectService {
             throw new ProjectPasswordInvalidException();
         }
 
+        RecruitmentPositionDto.toEntities(request.getRecruitmentPositions());
         User user = findUser(userPrincipal.getId());
         String semester = getCurrentSemester();
 
@@ -119,6 +121,7 @@ public class ProjectService {
             .toList();
     }
 
+    @Transactional(readOnly = true)
     public ProjectDetailsResponse getProjectDetails(Long projectId, UserPrincipal userPrincipal) {
         Project project = findProject(projectId);
 
@@ -134,6 +137,7 @@ public class ProjectService {
     }
 
     @CacheEvict(value = "projectList", allEntries = true)
+    @Transactional(readOnly = true)
     public ProjectDetailsResponse getProjectDetailsForUpdate(
         Long projectId,
         UserPrincipal userPrincipal
@@ -174,6 +178,8 @@ public class ProjectService {
         if (!canManage(project, user)) {
             throw new ForbiddenException("프로젝트 수정 권한이 없습니다.");
         }
+
+        RecruitmentPositionDto.toEntities(request.getRecruitmentPositions());
 
         // 썸네일 이미지가 없으면 유지 or 있으면 변경
         if (hasFile(request.getThumbnailFiles())) {

--- a/server/src/main/java/wap/web2/server/teambuild/dto/response/ProjectTemplate.java
+++ b/server/src/main/java/wap/web2/server/teambuild/dto/response/ProjectTemplate.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import wap.web2.server.teambuild.service.ProjectApplicationPositions;
 import wap.web2.server.project.entity.Project;
 import wap.web2.server.project.entity.TechStack;
 
@@ -17,6 +18,7 @@ public class ProjectTemplate {
     private String summary;
     private String projectType;
     private List<String> techStack;
+    private List<String> firstRoundRecruitPositions;
 
     public static ProjectTemplate from(Project project) {
         List<TechStack> techStacks = project.getTechStacks();
@@ -27,7 +29,8 @@ public class ProjectTemplate {
             project.getTitle(),
             project.getSummary(),
             project.getProjectType(),
-            techStackNames
+            techStackNames,
+            ProjectApplicationPositions.firstRound(project).stream().map(Enum::name).toList()
         );
     }
 }

--- a/server/src/main/java/wap/web2/server/teambuild/entity/Position.java
+++ b/server/src/main/java/wap/web2/server/teambuild/entity/Position.java
@@ -1,11 +1,22 @@
 package wap.web2.server.teambuild.entity;
 
+import java.util.Locale;
+import java.util.Optional;
+
 public enum Position {
-    FRONTEND,
-    BACKEND,
-    AI,
-    DESIGN,
-    APP,
-    GAME,
-    EMBEDDED
+    FRONTEND, BACKEND, AI, DESIGN, APP, GAME, EMBEDDED;
+
+    public static Optional<Position> fromRecruitmentRole(String role) {
+        if (role == null) return Optional.empty();
+        return Optional.ofNullable(switch (role.strip().toUpperCase(Locale.ROOT)) {
+            case "FRONTEND", "프론트엔드", "CLIENT" -> FRONTEND;
+            case "BACKEND", "백엔드", "SERVER" -> BACKEND;
+            case "AI" -> AI;
+            case "DESIGN", "DESIGNER", "디자인", "디자이너" -> DESIGN;
+            case "APP", "앱" -> APP;
+            case "GAME", "게임" -> GAME;
+            case "EMBEDDED", "임베디드", "HARDWARE", "하드웨어" -> EMBEDDED;
+            default -> null;
+        });
+    }
 }

--- a/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
+++ b/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
@@ -85,10 +85,18 @@ public class ApplyService {
                 throw new BadRequestException("동일한 프로젝트와 직무에 중복 지원할 수 없습니다.");
             }
         }
+        Map<Long, Project> projects = new java.util.HashMap<>();
+        for (ApplyRequest entry : applies) {
+            Project project = projects.computeIfAbsent(entry.getProjectId(), this::findProject);
+            if (round == 1 && !ProjectApplicationPositions.firstRound(project)
+                .contains(parsePosition(entry.getPosition()))) {
+                throw new BadRequestException("프로젝트에서 모집하지 않는 직무로는 지원할 수 없습니다.");
+            }
+        }
         int priority = existing.stream().mapToInt(ProjectApply::getPriority).max().orElse(0) + 1;
 
         for (ApplyRequest applyRequest : applies) {
-            Project project = findProject(applyRequest.getProjectId());
+            Project project = projects.get(applyRequest.getProjectId());
             log.info(
                 "apply-user:{},priority:{},project:{}",
                 userPrincipal.getName(),

--- a/server/src/main/java/wap/web2/server/teambuild/service/ProjectApplicationPositions.java
+++ b/server/src/main/java/wap/web2/server/teambuild/service/ProjectApplicationPositions.java
@@ -1,0 +1,17 @@
+package wap.web2.server.teambuild.service;
+
+import java.util.List;
+import wap.web2.server.project.entity.Project;
+import wap.web2.server.teambuild.entity.Position;
+
+public final class ProjectApplicationPositions {
+    private ProjectApplicationPositions() {}
+
+    public static List<Position> firstRound(Project project) {
+        return project.getRecruitmentPositions().stream()
+            .filter(position -> position.getCount() != null && position.getCount() > 0)
+            .flatMap(position -> Position.fromRecruitmentRole(position.getRole()).stream())
+            .distinct()
+            .toList();
+    }
+}

--- a/server/src/main/resources/db/migration/V5__add_project_recruitment_positions.sql
+++ b/server/src/main/resources/db/migration/V5__add_project_recruitment_positions.sql
@@ -1,0 +1,9 @@
+CREATE TABLE project_recruitment_position (
+    project_id BIGINT NOT NULL,
+    position_order INT NOT NULL,
+    role VARCHAR(50) NOT NULL,
+    headcount INT NOT NULL,
+    PRIMARY KEY (project_id, position_order),
+    CONSTRAINT fk_recruitment_position_project FOREIGN KEY (project_id) REFERENCES project (project_id),
+    CONSTRAINT chk_recruitment_headcount CHECK (headcount > 0)
+);

--- a/server/src/test/java/wap/web2/server/project/service/ApplyServiceTest.java
+++ b/server/src/test/java/wap/web2/server/project/service/ApplyServiceTest.java
@@ -24,6 +24,7 @@ import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.member.entity.User;
 import wap.web2.server.member.repository.UserRepository;
 import wap.web2.server.project.entity.Project;
+import wap.web2.server.project.entity.RecruitmentPosition;
 import wap.web2.server.project.repository.ProjectRepository;
 import wap.web2.server.teambuild.dto.request.ProjectAppliesRequest;
 import wap.web2.server.teambuild.dto.request.ProjectAppliesRequest.ApplyRequest;
@@ -60,9 +61,9 @@ class ApplyServiceTest {
         User user = new User();
         when(userRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(user));
 
-        Project p1 = Project.builder().projectId(10L).title("A").build();
-        Project p2 = Project.builder().projectId(20L).title("B").build();
-        Project p3 = Project.builder().projectId(30L).title("C").build();
+        Project p1 = Project.builder().projectId(10L).title("A").recruitmentPositions(List.of(new RecruitmentPosition("백엔드", 1))).build();
+        Project p2 = Project.builder().projectId(20L).title("B").recruitmentPositions(List.of(new RecruitmentPosition("프론트엔드", 1))).build();
+        Project p3 = Project.builder().projectId(30L).title("C").recruitmentPositions(List.of(new RecruitmentPosition("AI", 1))).build();
         when(projectRepository.findById(10L)).thenReturn(Optional.of(p1));
         when(projectRepository.findById(20L)).thenReturn(Optional.of(p2));
         when(projectRepository.findById(30L)).thenReturn(Optional.of(p3));

--- a/server/src/test/java/wap/web2/server/project/service/ProjectServiceTest.java
+++ b/server/src/test/java/wap/web2/server/project/service/ProjectServiceTest.java
@@ -21,12 +21,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
+import wap.web2.server.exception.BadRequestException;
 import wap.web2.server.exception.ForbiddenException;
 import wap.web2.server.exception.ProjectPasswordInvalidException;
 import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.member.entity.Role;
 import wap.web2.server.member.entity.User;
 import wap.web2.server.member.repository.UserRepository;
+import wap.web2.server.project.dto.RecruitmentPositionDto;
+import wap.web2.server.project.dto.response.ProjectDetailsResponse;
 import wap.web2.server.project.dto.TeamMemberDto;
 import wap.web2.server.project.dto.TechStackDto;
 import wap.web2.server.project.dto.request.ProjectRequest;
@@ -252,6 +255,55 @@ class ProjectServiceTest {
         assertThatThrownBy(() -> projectService.update(10L, request, principal))
             .isInstanceOf(ProjectPasswordInvalidException.class);
         verifyNoInteractions(projectRepository, objectStorageService);
+    }
+
+    @Test
+    void 모집_인원을_생성_조회_수정_삭제한다() {
+        var positions = List.of(
+            new RecruitmentPositionDto("프론트엔드", 3),
+            new RecruitmentPositionDto("백엔드", 2));
+        ProjectRequest request = baseRequestBuilder().recruitmentPositions(positions).build();
+        Project project = request.toEntity(request, "2026-02", List.of(), "", owner());
+        assertThat(ProjectDetailsResponse.from(project)
+            .getRecruitmentPositions()).containsExactlyElementsOf(positions);
+        project.update(baseRequestBuilder().build());
+        assertThat(project.getRecruitmentPositions()).hasSize(2);
+        project.update(baseRequestBuilder().recruitmentPositions(List.of(positions.get(1))).build());
+        assertThat(project.getRecruitmentPositions()).singleElement().satisfies(position -> {
+            assertThat(position.getRole()).isEqualTo("백엔드");
+            assertThat(position.getCount()).isEqualTo(2);
+        });
+        project.update(baseRequestBuilder().recruitmentPositions(List.of()).build());
+        assertThat(project.getRecruitmentPositions()).isEmpty();
+        assertThat(baseRequestBuilder().build().toEntity(baseRequestBuilder().build(), "2026-02", List.of(), "", owner())
+            .getRecruitmentPositions()).isEmpty();
+    }
+
+    @Test
+    void 잘못된_모집_정보는_거절한다() {
+        var invalid = java.util.Arrays.asList(
+            new RecruitmentPositionDto(" ", 1),
+            new RecruitmentPositionDto("개발", 0),
+            new RecruitmentPositionDto("개발", -1),
+            new RecruitmentPositionDto("개발", null),
+            new RecruitmentPositionDto("가".repeat(51), 1), null);
+        for (var position : invalid) {
+            assertThatThrownBy(() -> RecruitmentPositionDto.toEntities(
+                java.util.Arrays.asList(position)))
+                .isInstanceOf(BadRequestException.class);
+        }
+        assertThatThrownBy(() -> RecruitmentPositionDto.toEntities(List.of(
+            new RecruitmentPositionDto("개발", 1),
+            new RecruitmentPositionDto(" 개발 ", 2))))
+            .isInstanceOf(BadRequestException.class);
+    }
+
+    @Test
+    void 소수_모집_인원은_JSON_변환에서_거절한다() {
+        var mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        assertThatThrownBy(() -> mapper.readValue(
+            "{\"recruitmentPositions\":[{\"role\":\"백엔드\",\"count\":1.5}]}", ProjectRequest.class))
+            .isInstanceOf(com.fasterxml.jackson.core.JsonProcessingException.class);
     }
 
     private ProjectRequest.ProjectRequestBuilder baseRequestBuilder() {

--- a/server/src/test/java/wap/web2/server/teambuild/service/ApplicationChoiceTest.java
+++ b/server/src/test/java/wap/web2/server/teambuild/service/ApplicationChoiceTest.java
@@ -18,6 +18,7 @@ import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.member.entity.User;
 import wap.web2.server.member.repository.UserRepository;
 import wap.web2.server.project.entity.Project;
+import wap.web2.server.project.entity.RecruitmentPosition;
 import wap.web2.server.project.repository.ProjectRepository;
 import wap.web2.server.teambuild.dto.request.ProjectAppliesRequest;
 import wap.web2.server.teambuild.dto.request.ProjectAppliesRequest.ApplyRequest;
@@ -52,7 +53,7 @@ class ApplicationChoiceTest {
     void acceptsFiveProjectPositionPairsAcrossTwoProjects() {
         UserPrincipal principal = applicant();
         when(projectRepository.findById(anyLong())).thenAnswer(i -> Optional.of(
-            Project.builder().projectId(i.getArgument(0)).build()));
+            Project.builder().projectId(i.getArgument(0)).recruitmentPositions(List.of(new RecruitmentPosition("프론트엔드", 3), new RecruitmentPosition("백엔드", 2), new RecruitmentPosition("AI", 1))).build()));
         service.apply(principal, new ProjectAppliesRequest(List.of(
             new ApplyRequest(10L, "frontend", "a"), new ApplyRequest(10L, "backend", "b"),
             new ApplyRequest(20L, "frontend", "c"), new ApplyRequest(20L, "backend", "d"),
@@ -74,7 +75,7 @@ class ApplicationChoiceTest {
     @Test
     void countsPreviouslySubmittedApplicationsInSameRound() {
         UserPrincipal principal = applicant(2);
-        ProjectApply existing = ProjectApply.builder().project(Project.builder().projectId(10L).build())
+        ProjectApply existing = ProjectApply.builder().project(Project.builder().projectId(10L).recruitmentPositions(List.of(new RecruitmentPosition("프론트엔드", 3))).build())
             .priority(1).position(Position.AI).build();
         when(applyRepository.findAllByUserIdAndSemesterAndRound(1L, generateSemester(), 2))
             .thenReturn(java.util.Collections.nCopies(5, existing));
@@ -91,7 +92,7 @@ class ApplicationChoiceTest {
             { "applies": [{"projectId":10,"position":"frontend","comment":"a","experience":"React"}] }""",
             ProjectAppliesRequest.class);
         UserPrincipal principal = applicant();
-        when(projectRepository.findById(10L)).thenReturn(Optional.of(Project.builder().projectId(10L).build()));
+        when(projectRepository.findById(10L)).thenReturn(Optional.of(Project.builder().projectId(10L).recruitmentPositions(List.of(new RecruitmentPosition("프론트엔드", 3))).build()));
         service.apply(principal, request, 1);
         ArgumentCaptor<ProjectApply> saved = ArgumentCaptor.forClass(ProjectApply.class);
         verify(applyRepository).save(saved.capture());
@@ -101,4 +102,34 @@ class ApplicationChoiceTest {
         assertThat(json.at("/applies/0/career").asText()).isEqualTo("React");
         assertThat(new ApplyRequest(10L, "AI", "a", "legacy").getExperience()).isEqualTo("legacy");
     }
+    @Test
+    void rejectsUnrecruitedPositionBeforeSavingAnyApplication() {
+        UserPrincipal principal = applicant();
+        when(projectRepository.findById(10L)).thenReturn(Optional.of(Project.builder().projectId(10L)
+            .recruitmentPositions(List.of(new RecruitmentPosition("백엔드", 2))).build()));
+        assertThatThrownBy(() -> service.apply(principal, new ProjectAppliesRequest(List.of(
+            new ApplyRequest(10L, "BACKEND", "a"), new ApplyRequest(10L, "FRONTEND", "b"))), 1))
+            .isInstanceOf(BadRequestException.class).hasMessageContaining("모집하지 않는 직무");
+        verify(applyRepository, never()).save(any());
+    }
+
+    @Test
+    void rejectsProjectWithoutRecruitmentPositionsInFirstRound() {
+        UserPrincipal principal = applicant();
+        when(projectRepository.findById(10L)).thenReturn(Optional.of(Project.builder().projectId(10L).build()));
+        assertThatThrownBy(() -> service.apply(principal, new ProjectAppliesRequest(List.of(
+            new ApplyRequest(10L, "BACKEND", "a"))), 1)).isInstanceOf(BadRequestException.class);
+        verify(applyRepository, never()).save(any());
+    }
+
+    @Test
+    void projectListExposesOnlySupportedRecruitmentPositions() {
+        Project project = Project.builder().recruitmentPositions(List.of(
+            new RecruitmentPosition("프론트엔드", 3), new RecruitmentPosition("backend", 2),
+            new RecruitmentPosition("Server", 1), new RecruitmentPosition("PM", 1),
+            new RecruitmentPosition("GAME", 0))).build();
+        assertThat(wap.web2.server.teambuild.dto.response.ProjectTemplate.from(project)
+            .getFirstRoundRecruitPositions()).containsExactly("FRONTEND", "BACKEND");
+    }
+
 }

--- a/server/src/test/java/wap/web2/server/teambuild/service/ApplyRoundTest.java
+++ b/server/src/test/java/wap/web2/server/teambuild/service/ApplyRoundTest.java
@@ -26,6 +26,7 @@ import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.member.entity.User;
 import wap.web2.server.member.repository.UserRepository;
 import wap.web2.server.project.entity.Project;
+import wap.web2.server.project.entity.RecruitmentPosition;
 import wap.web2.server.project.repository.ProjectRepository;
 import wap.web2.server.teambuild.dto.RecruitmentDto;
 import wap.web2.server.teambuild.dto.request.ProjectAppliesRequest;
@@ -75,7 +76,7 @@ class ApplyRoundTest {
         user.setId(1L);
         when(principal.getId()).thenReturn(1L);
         when(userRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(user));
-        when(projectRepository.findById(10L)).thenReturn(Optional.of(Project.builder().projectId(10L).build()));
+        when(projectRepository.findById(10L)).thenReturn(Optional.of(Project.builder().projectId(10L).recruitmentPositions(round == 1 ? List.of(new RecruitmentPosition("백엔드", 2)) : List.of()).build()));
         status(TeamBuildingStatus.APPLY, round);
         service.apply(principal, new ProjectAppliesRequest(List.of(
             new ProjectAppliesRequest.ApplyRequest(10L, "BACKEND", "comment"))), round);


### PR DESCRIPTION
## 📌 관련 이슈

- 별도 연결 이슈 없음

## ✨ PR 세부 내용

프로젝트 게시글에 직무별 모집 인원을 등록하고, 1차 팀빌딩에서는 해당 프로젝트가 모집하는 직무로만 지원할 수 있도록 변경했습니다. 예를 들어 백엔드 2명만 모집하는 프로젝트에는 프론트엔드로 지원할 수 없습니다.

- 프로젝트 작성·수정 화면에 모집 직무와 인원 추가·삭제 기능을 제공하고 상세 화면에 표시합니다.
- 모집 정보를 저장하는 테이블과 V5 Flyway 마이그레이션을 추가했습니다. 빈 직무, 중복 직무, 양수가 아닌 인원 및 소수 입력을 검증합니다.
- 1차 지원 목록에 게시글의 모집 직무를 팀빌딩 코드로 변환해 제공합니다. 모집 정보가 없는 프로젝트는 지원할 수 없습니다.
- 서버에서도 모든 지원서의 모집 직무를 저장 전에 검사합니다. 2차 지원 동작은 유지합니다.
- 작성 폼의 기존 React import 오류를 수정했습니다.

## 👀 확인해주세요!

- 프로젝트 모집 정보 관련 서버 테스트와 팀빌딩 지원 관련 서버 테스트 통과
- 프로젝트 작성·상세 화면 테스트 22개, 팀빌딩 지원 화면 테스트 16개 통과
- 클라이언트 프로덕션 빌드 통과
- 서버 전체 테스트 실행에서는 기존 YAML 설정 파싱 오류로 `ServerApplicationTests.contextLoads` 1개 실패
- 배포 시 V5 마이그레이션이 필요합니다. 기존 프로젝트가 1차 지원을 받으려면 모집 직무를 등록해야 합니다.
- 팀빌딩에서 지원하는 직무 코드와 대응되는 모집 직무만 지원 선택지로 제공됩니다.

## ⌛ 소요 시간

- 별도 측정하지 않음
