### PR TITLE
feat: 프로젝트 모집 직무 선택과 모집 인원 UI 개선

### DIFF
--- a/client/src/assets/ProjectCreation/ProjectForm.module.css
+++ b/client/src/assets/ProjectCreation/ProjectForm.module.css
@@ -218,7 +218,8 @@
   font-size: 13px;
 }
 
-.recruitment_row input {
+.recruitment_row input,
+.recruitment_row select {
   box-sizing: border-box;
   width: 100%;
   margin-top: 6px;

--- a/client/src/assets/ProjectCreation/ProjectForm.module.css
+++ b/client/src/assets/ProjectCreation/ProjectForm.module.css
@@ -195,44 +195,109 @@
 }
 
 .recruitment {
-  margin: 24px 0;
+  box-sizing: border-box;
+  width: 90%;
+  margin: 20px auto;
+  padding: 20px clamp(16px, 8vw, 33px);
+  border-radius: 10px;
+  background-color: #2a2a2a;
   color: #ebebeb;
   text-align: left;
 }
 
+.recruitment h3 {
+  margin: 0 0 10px;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.5;
+}
+
 .recruitment p {
+  margin: 0 0 16px;
   color: #b5b5b5;
-  font-size: 14px;
+  font-size: 11px;
+  line-height: 1.6;
 }
 
 .recruitment_row {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) auto;
   align-items: end;
-  gap: 8px;
+  gap: 6px;
   margin-bottom: 12px;
 }
 
 .recruitment_row label {
-  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
   min-width: 0;
-  font-size: 13px;
+  color: #b5b5b5;
+  font-size: 11px;
+  line-height: 1.5;
 }
 
 .recruitment_row input,
 .recruitment_row select {
   box-sizing: border-box;
   width: 100%;
-  margin-top: 6px;
-  padding: 8px;
-  border: 1px solid #666;
-  border-radius: 4px;
-  background: #1f1f1f;
-  color: #ebebeb;
+  min-width: 0;
+  height: 32px;
+  margin: 0;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 20px;
+  background-color: #4a4a4a;
+  color: #ffffff;
+  font: inherit;
+  font-size: 12px;
 }
 
 .recruitment button {
-  padding: 8px;
+  box-sizing: border-box;
+  min-height: 32px;
+  padding: 6px 12px;
   border: 0;
-  border-radius: 4px;
+  border-radius: 20px;
+  background-color: #efefef;
+  color: #000000;
+  font: inherit;
+  font-size: 12px;
+  line-height: 20px;
+  white-space: nowrap;
   cursor: pointer;
+}
+
+.recruitment > button {
+  display: block;
+  margin: 16px auto 0;
+  padding-right: 16px;
+  padding-left: 16px;
+}
+
+.recruitment button:hover {
+  background-color: #d9d9d9;
+}
+
+.recruitment input:focus-visible,
+.recruitment select:focus-visible,
+.recruitment button:focus-visible {
+  outline: 2px solid #abd4fd;
+  outline-offset: 2px;
+}
+
+@media (max-width: 360px) {
+  .recruitment {
+    padding-right: 16px;
+    padding-left: 16px;
+  }
+
+  .recruitment_row {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+
+  .recruitment_row button {
+    grid-column: 2;
+    justify-self: end;
+  }
 }

--- a/client/src/components/ProjectCreation/ProjectFormNew.js
+++ b/client/src/components/ProjectCreation/ProjectFormNew.js
@@ -163,7 +163,7 @@ const ProjectFormNew = ({ isEdit = false, existingProject = null }) => {
       return;
     }
 
-    const recruitmentError = recruitmentPositionsError(recruitmentPositions);
+    const recruitmentError = recruitmentPositionsError(recruitmentPositions, !isEdit);
     if (recruitmentError) {
       alert(recruitmentError);
       return;
@@ -328,6 +328,7 @@ const ProjectFormNew = ({ isEdit = false, existingProject = null }) => {
         </div>
 
         <RecruitmentPositionInput
+          required={!isEdit}
           positions={recruitmentPositions}
           onChange={setRecruitmentPositions}
         />

--- a/client/src/components/ProjectCreation/ProjectFormNew.test.js
+++ b/client/src/components/ProjectCreation/ProjectFormNew.test.js
@@ -53,14 +53,14 @@ test("모집 직무를 추가하고 인원을 숫자로 저장한다", async () 
   await screen.findByText("2026년 2학기");
   fireEvent.click(screen.getByRole("button", { name: "모집 직무 추가" }));
   fireEvent.change(screen.getByLabelText("직무 1"), {
-    target: { value: " 프론트엔드 " },
+    target: { value: "FRONTEND" },
   });
   fireEvent.change(screen.getByLabelText("모집 인원 1 (명)"), {
     target: { value: "3" },
   });
   fireEvent.click(screen.getByRole("button", { name: "모집 직무 추가" }));
   fireEvent.change(screen.getByLabelText("직무 2"), {
-    target: { value: "백엔드" },
+    target: { value: "BACKEND" },
   });
   fireEvent.change(screen.getByLabelText("모집 인원 2 (명)"), {
     target: { value: "2" },
@@ -97,7 +97,7 @@ test("수정 화면에서 기존 모집 정보를 불러오고 모두 삭제할 
       />
     </MemoryRouter>,
   );
-  expect(screen.getByLabelText("직무 1").value).toBe("백엔드");
+  expect(screen.getByLabelText("직무 1").value).toBe("BACKEND");
   expect(screen.getByLabelText("모집 인원 1 (명)").value).toBe("2");
   fireEvent.click(screen.getByRole("button", { name: "모집 직무 1 삭제" }));
   fireEvent.change(screen.getByLabelText("비밀번호"), {
@@ -128,7 +128,7 @@ test.each([0, -1, 1.5, ""])(
     await screen.findByText("2026년 2학기");
     fireEvent.click(screen.getByRole("button", { name: "모집 직무 추가" }));
     fireEvent.change(screen.getByLabelText("직무 1"), {
-      target: { value: "백엔드" },
+      target: { value: "BACKEND" },
     });
     fireEvent.change(screen.getByLabelText("모집 인원 1 (명)"), {
       target: { value: count },

--- a/client/src/components/ProjectCreation/ProjectFormNew.test.js
+++ b/client/src/components/ProjectCreation/ProjectFormNew.test.js
@@ -145,3 +145,17 @@ test.each([0, -1, 1.5, ""])(
     );
   },
 );
+
+ test.each([false, true])("신규 작성은 모집 정보가 비어 있으면 제출하지 않는다 (추가 후 삭제: %s)", async (remove) => {
+  render(<MemoryRouter><ProjectFormNew /></MemoryRouter>);
+  await screen.findByText("2026년 2학기");
+  expect(screen.getByText("모집할 직무와 인원을 최소 한 개 입력해 주세요. (필수)")).toBeTruthy();
+  if (remove) {
+    fireEvent.click(screen.getByRole("button", { name: "모집 직무 추가" }));
+    fireEvent.click(screen.getByRole("button", { name: "모집 직무 1 삭제" }));
+  }
+  fireEvent.change(screen.getByLabelText("비밀번호"), { target: { value: "pw" } });
+  fireEvent.submit(screen.getByRole("button", { name: "프로젝트 생성" }).closest("form"));
+  expect(projectApi.createProject).not.toHaveBeenCalled();
+  expect(window.alert).toHaveBeenCalledWith("모집 직무와 인원을 최소 한 개 입력해 주세요.");
+});

--- a/client/src/components/ProjectCreation/RecruitmentPositionInput.js
+++ b/client/src/components/ProjectCreation/RecruitmentPositionInput.js
@@ -46,8 +46,8 @@ export default function RecruitmentPositionInput({ positions, onChange }) {
   };
 
   return (
-    <section className={styles.recruitment} aria-label="직무별 모집 인원">
-      <h3>직무별 모집 인원</h3>
+    <section className={styles.recruitment} aria-label="모집 인원 (팀장 제외)">
+      <h3>모집 인원 (팀장 제외)</h3>
       <p>모집할 직무와 인원을 추가해 주세요. (선택)</p>
       {positions.map((position, index) => (
         <div className={styles.recruitment_row} key={index}>

--- a/client/src/components/ProjectCreation/RecruitmentPositionInput.js
+++ b/client/src/components/ProjectCreation/RecruitmentPositionInput.js
@@ -15,7 +15,10 @@ const normalizeRole = (role) => {
   );
 };
 
-export const recruitmentPositionsError = (positions) => {
+export const recruitmentPositionsError = (positions, required = false) => {
+  if (required && positions.length === 0) {
+    return "모집 직무와 인원을 최소 한 개 입력해 주세요.";
+  }
   const roles = positions.map(({ role }) => normalizeRole(role));
   if (roles.some((role) => !role)) {
     return "존재하는 모집 직무를 선택해 주세요.";
@@ -36,7 +39,7 @@ export const recruitmentPositionsError = (positions) => {
   return "";
 };
 
-export default function RecruitmentPositionInput({ positions, onChange }) {
+export default function RecruitmentPositionInput({ positions, onChange, required = false }) {
   const update = (index, field, value) => {
     onChange(
       positions.map((position, i) =>
@@ -48,7 +51,9 @@ export default function RecruitmentPositionInput({ positions, onChange }) {
   return (
     <section className={styles.recruitment} aria-label="모집 인원 (팀장 제외)">
       <h3>모집 인원 (팀장 제외)</h3>
-      <p>모집할 직무와 인원을 추가해 주세요. (선택)</p>
+      <p>{required
+        ? "모집할 직무와 인원을 최소 한 개 입력해 주세요. (필수)"
+        : "모집할 직무와 인원을 추가해 주세요. (선택)"}</p>
       {positions.map((position, index) => (
         <div className={styles.recruitment_row} key={index}>
           <label>

--- a/client/src/components/ProjectCreation/RecruitmentPositionInput.js
+++ b/client/src/components/ProjectCreation/RecruitmentPositionInput.js
@@ -53,7 +53,7 @@ export default function RecruitmentPositionInput({ positions, onChange, required
       <h3>모집 인원 (팀장 제외)</h3>
       <p>{required
         ? "모집할 직무와 인원을 최소 한 개 입력해 주세요. (필수)"
-        : "모집할 직무와 인원을 추가해 주세요. (선택)"}</p>
+        : "모집할 직무와 인원을 추가해 주세요."}</p>
       {positions.map((position, index) => (
         <div className={styles.recruitment_row} key={index}>
           <label>

--- a/client/src/components/ProjectCreation/RecruitmentPositionInput.js
+++ b/client/src/components/ProjectCreation/RecruitmentPositionInput.js
@@ -1,10 +1,24 @@
 import React from "react";
+import { POSITIONS } from "../../constants/positions";
+import { getPositionLabel } from "../../utils/teamBuildApplication";
 import styles from "../../assets/ProjectCreation/ProjectForm.module.css";
 
+const normalizeRole = (role) => {
+  const value = (role || "").trim();
+  const aliases = {
+    CLIENT: "FRONTEND", SERVER: "BACKEND", DESIGNER: "DESIGN",
+    디자인: "DESIGN", HARDWARE: "EMBEDDED", 하드웨어: "EMBEDDED",
+  };
+  const code = aliases[value.toUpperCase()] || value.toUpperCase();
+  return POSITIONS.find((position) =>
+    position === code || getPositionLabel(position) === value,
+  );
+};
+
 export const recruitmentPositionsError = (positions) => {
-  const roles = positions.map(({ role }) => role.trim());
-  if (roles.some((role) => !role || role.length > 50)) {
-    return "모집 직무는 1~50자로 입력해 주세요.";
+  const roles = positions.map(({ role }) => normalizeRole(role));
+  if (roles.some((role) => !role)) {
+    return "존재하는 모집 직무를 선택해 주세요.";
   }
   if (new Set(roles).size !== roles.length) {
     return "모집 직무가 중복되었습니다.";
@@ -39,13 +53,24 @@ export default function RecruitmentPositionInput({ positions, onChange }) {
         <div className={styles.recruitment_row} key={index}>
           <label>
             직무 {index + 1}
-            <input
-              value={position.role}
-              placeholder="예: 프론트엔드"
-              maxLength={50}
+            <select
+              value={normalizeRole(position.role) || ""}
               required
-              onChange={(event) => update(index, "role", event.target.value)}
-            />
+              onChange={(event) => update(index, "role", getPositionLabel(event.target.value))}
+            >
+              <option value="">직무 선택</option>
+              {POSITIONS.map((role) => (
+                <option
+                  key={role}
+                  value={role}
+                  disabled={positions.some((other, i) =>
+                    i !== index && normalizeRole(other.role) === role,
+                  )}
+                >
+                  {getPositionLabel(role)}
+                </option>
+              ))}
+            </select>
           </label>
           <label>
             모집 인원 {index + 1} (명)

--- a/client/src/components/ProjectCreation/RecruitmentPositionInput.test.js
+++ b/client/src/components/ProjectCreation/RecruitmentPositionInput.test.js
@@ -1,0 +1,34 @@
+import React from "react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import RecruitmentPositionInput, { recruitmentPositionsError } from "./RecruitmentPositionInput";
+
+test("기존 직무만 선택할 수 있고 이미 선택한 직무는 비활성화한다", () => {
+  const onChange = jest.fn();
+  render(<RecruitmentPositionInput positions={[
+    { role: "백엔드", count: 2 }, { role: "", count: 1 },
+  ]} onChange={onChange} />);
+  const select = screen.getByRole("combobox", { name: "직무 2" });
+  expect(within(select).getAllByRole("option").map((option) => option.value))
+    .toEqual(["", "FRONTEND", "BACKEND", "DESIGN", "AI", "APP", "EMBEDDED", "GAME"]);
+  expect(within(select).getByRole("option", { name: "백엔드" }).disabled).toBe(true);
+  fireEvent.change(select, { target: { value: "FRONTEND" } });
+  expect(onChange).toHaveBeenCalledWith([
+    { role: "백엔드", count: 2 }, { role: "프론트엔드", count: 1 },
+  ]);
+});
+
+test("존재하지 않는 직무와 같은 직무의 별칭 중복을 거절한다", () => {
+  expect(recruitmentPositionsError([{ role: "없는직무", count: 1 }]))
+    .toBe("존재하는 모집 직무를 선택해 주세요.");
+  expect(recruitmentPositionsError([
+    { role: "BACKEND", count: 1 }, { role: "백엔드", count: 2 },
+  ])).toBe("모집 직무가 중복되었습니다.");
+});
+
+test.each(["DESIGNER", "디자인", "하드웨어", " backend "])(
+  "기존 직무 별칭 %s를 선택값으로 표시한다", (role) => {
+    render(<RecruitmentPositionInput positions={[{ role, count: 1 }]} onChange={jest.fn()} />);
+    expect(screen.getByRole("combobox", { name: "직무 1" }).value).not.toBe("");
+    expect(recruitmentPositionsError([{ role, count: 1 }])).toBe("");
+  },
+);

--- a/client/src/components/ProjectDetail/ProjectDetailForm.js
+++ b/client/src/components/ProjectDetail/ProjectDetailForm.js
@@ -118,8 +118,8 @@ const ProjectDetailForm = () => {
         </div>
       </div>
 
-      <section aria-label="직무별 모집 인원">
-        <h3>직무별 모집 인원</h3>
+      <section aria-label="모집 인원 (팀장 제외)">
+        <h3>모집 인원 (팀장 제외)</h3>
         {projectData.recruitmentPositions?.length > 0 ? (
           <p>
             {projectData.recruitmentPositions

--- a/server/src/main/java/wap/web2/server/project/dto/RecruitmentPositionDto.java
+++ b/server/src/main/java/wap/web2/server/project/dto/RecruitmentPositionDto.java
@@ -7,11 +7,12 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import wap.web2.server.exception.BadRequestException;
 import wap.web2.server.project.entity.RecruitmentPosition;
+import wap.web2.server.teambuild.entity.Position;
 
 public record RecruitmentPositionDto(
     String role,
@@ -37,14 +38,16 @@ public record RecruitmentPositionDto(
         if (positions == null) {
             return result;
         }
-        Set<String> roles = new HashSet<>();
+        Set<Position> roles = EnumSet.noneOf(Position.class);
         for (RecruitmentPositionDto position : positions) {
             if (position == null || position.role() == null || position.role().isBlank()
                 || position.role().strip().length() > 50) {
                 throw new BadRequestException("모집 직무는 1~50자로 입력해 주세요.");
             }
             String role = position.role().strip();
-            if (!roles.add(role)) {
+            Position selectedPosition = Position.fromRecruitmentRole(role)
+                .orElseThrow(() -> new BadRequestException("존재하는 모집 직무를 선택해 주세요."));
+            if (!roles.add(selectedPosition)) {
                 throw new BadRequestException("모집 직무가 중복되었습니다.");
             }
             if (position.count() == null || position.count() < 1) {

--- a/server/src/main/java/wap/web2/server/project/service/ProjectService.java
+++ b/server/src/main/java/wap/web2/server/project/service/ProjectService.java
@@ -16,6 +16,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import wap.web2.server.exception.BadRequestException;
 import wap.web2.server.exception.ForbiddenException;
 import wap.web2.server.exception.ProjectPasswordInvalidException;
 import wap.web2.server.exception.ResourceNotFoundException;
@@ -59,6 +60,9 @@ public class ProjectService {
             throw new ProjectPasswordInvalidException();
         }
 
+        if (request.getRecruitmentPositions() == null || request.getRecruitmentPositions().isEmpty()) {
+            throw new BadRequestException("모집 직무와 인원을 최소 한 개 입력해 주세요.");
+        }
         RecruitmentPositionDto.toEntities(request.getRecruitmentPositions());
         User user = findUser(userPrincipal.getId());
         String semester = getCurrentSemester();

--- a/server/src/test/java/wap/web2/server/project/service/ProjectServiceTest.java
+++ b/server/src/test/java/wap/web2/server/project/service/ProjectServiceTest.java
@@ -338,6 +338,48 @@ class ProjectServiceTest {
             .isInstanceOf(com.fasterxml.jackson.core.JsonProcessingException.class);
     }
 
+    @Test
+    void 신규_프로젝트는_모집_정보_누락과_빈_목록을_거절한다() {
+        for (List<RecruitmentPositionDto> positions : java.util.Arrays.<List<RecruitmentPositionDto>>asList(null, List.of())) {
+            ProjectRequest request = baseRequestBuilder().recruitmentPositions(positions).build();
+            assertThatThrownBy(() -> projectService.save(request, null))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("모집 직무와 인원을 최소 한 개 입력해 주세요.");
+        }
+        verifyNoInteractions(projectRepository, userRepository, objectStorageService);
+    }
+
+    @Test
+    void 신규_프로젝트는_모집_정보가_있으면_등록한다() throws Exception {
+        User owner = owner();
+        UserPrincipal principal = principal(owner.getId());
+        when(userRepository.findById(owner.getId())).thenReturn(Optional.of(owner));
+        ProjectRequest request = baseRequestBuilder()
+            .recruitmentPositions(List.of(new RecruitmentPositionDto("백엔드", 1))).build();
+
+        assertThat(projectService.save(request, principal)).isEqualTo("등록되었습니다.");
+        var saved = org.mockito.ArgumentCaptor.forClass(Project.class);
+        verify(projectRepository).save(saved.capture());
+        assertThat(saved.getValue().getRecruitmentPositions()).singleElement().satisfies(position -> {
+            assertThat(position.getRole()).isEqualTo("백엔드");
+            assertThat(position.getCount()).isEqualTo(1);
+        });
+    }
+
+    @Test
+    void 기존_프로젝트는_빈_모집_목록으로_수정할_수_있다() throws Exception {
+        User owner = owner();
+        UserPrincipal principal = principal(owner.getId());
+        Project project = project(owner);
+        when(userRepository.findById(owner.getId())).thenReturn(Optional.of(owner));
+        when(projectRepository.findById(10L)).thenReturn(Optional.of(project));
+
+        assertThat(projectService.update(10L,
+            baseRequestBuilder().recruitmentPositions(List.of()).build(), principal))
+            .isEqualTo("수정되었습니다.");
+        assertThat(project.getRecruitmentPositions()).isEmpty();
+    }
+
     private ProjectRequest.ProjectRequestBuilder baseRequestBuilder() {
         return ProjectRequest.builder()
             .title("updated title")

--- a/server/src/test/java/wap/web2/server/project/service/ProjectServiceTest.java
+++ b/server/src/test/java/wap/web2/server/project/service/ProjectServiceTest.java
@@ -283,9 +283,9 @@ class ProjectServiceTest {
     void 잘못된_모집_정보는_거절한다() {
         var invalid = java.util.Arrays.asList(
             new RecruitmentPositionDto(" ", 1),
-            new RecruitmentPositionDto("개발", 0),
-            new RecruitmentPositionDto("개발", -1),
-            new RecruitmentPositionDto("개발", null),
+            new RecruitmentPositionDto("백엔드", 0),
+            new RecruitmentPositionDto("백엔드", -1),
+            new RecruitmentPositionDto("백엔드", null),
             new RecruitmentPositionDto("가".repeat(51), 1), null);
         for (var position : invalid) {
             assertThatThrownBy(() -> RecruitmentPositionDto.toEntities(
@@ -293,9 +293,41 @@ class ProjectServiceTest {
                 .isInstanceOf(BadRequestException.class);
         }
         assertThatThrownBy(() -> RecruitmentPositionDto.toEntities(List.of(
-            new RecruitmentPositionDto("개발", 1),
-            new RecruitmentPositionDto(" 개발 ", 2))))
+            new RecruitmentPositionDto("백엔드", 1),
+            new RecruitmentPositionDto(" BACKEND ", 2))))
             .isInstanceOf(BadRequestException.class);
+    }
+
+    @Test
+    void 존재하지_않는_모집_직무는_등록과_수정에서_거절한다() {
+        ProjectRequest request = baseRequestBuilder()
+            .recruitmentPositions(List.of(new RecruitmentPositionDto("없는직무", 1))).build();
+        User owner = owner();
+        UserPrincipal principal = principal(owner.getId());
+        Project project = project(owner);
+        when(userRepository.findById(owner.getId())).thenReturn(Optional.of(owner));
+        when(projectRepository.findById(10L)).thenReturn(Optional.of(project));
+
+        assertThatThrownBy(() -> projectService.save(request, principal))
+            .isInstanceOf(BadRequestException.class)
+            .hasMessage("존재하는 모집 직무를 선택해 주세요.");
+        assertThatThrownBy(() -> projectService.update(10L, request, principal))
+            .isInstanceOf(BadRequestException.class)
+            .hasMessage("존재하는 모집 직무를 선택해 주세요.");
+        assertThat(project.getTitle()).isEqualTo("old title");
+        verify(projectRepository, never()).save(org.mockito.ArgumentMatchers.any());
+        verifyNoInteractions(objectStorageService);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"FRONTEND", "BACKEND", "AI", "DESIGN", "APP", "GAME", "EMBEDDED",
+        "프론트엔드", "백엔드", "디자인", "앱", "게임", "임베디드", " backend "})
+    void 정의된_모집_직무를_허용한다(String role) {
+        assertThat(RecruitmentPositionDto.toEntities(List.of(new RecruitmentPositionDto(role, 2))))
+            .singleElement().satisfies(position -> {
+                assertThat(position.getRole()).isEqualTo(role.strip());
+                assertThat(position.getCount()).isEqualTo(2);
+            });
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈

- 연결된 이슈 없음

## ✨ PR 세부 내용

프로젝트 모집 직무를 자유 입력하면 팀빌딩에서 인식하지 못하는 직무가 저장될 수 있어, 기존 7개 직무 중 선택하도록 변경했습니다.

- 작성·수정 화면에서 직무를 드롭다운으로 선택하고, 이미 선택한 직무는 다른 행에서 비활성화합니다.
- 서버에서도 존재하지 않는 직무와 동일 직무의 별칭 중복(예: `백엔드`와 `BACKEND`)을 거절합니다. 기존 한글 직무명과 별칭은 계속 허용합니다.
- 모집 인원 영역을 기존 폼과 일관된 카드로 구성하고 좁은 화면의 줄바꿈을 적용했습니다.
- 작성·수정 및 상세 화면의 제목을 `모집 인원 (팀장 제외)`로 통일했습니다.

## 👀 확인해주세요!

- 프로젝트 서비스 테스트 통과.
- 프런트엔드 작성·수정 폼 및 직무 선택 테스트 총 12개 통과.
- CSS 구문 및 diff 공백 검사 통과. 브라우저 시각 검증은 미실시.
- 서버 전체 테스트: 122개 중 1개 실패, 3개 스킵. 기존 설정 `optional:file:.env[.yml]`이 `KEY=VALUE` 형식의 `.env`를 YAML로 읽어 `ServerApplicationTests.contextLoads()`가 실패합니다.

## ⌛ 소요 시간

- 별도 측정하지 않음
