### PR TITLE
feat: 팀 빌딩 지원 완료 화면에 이동 버튼 추가

### DIFF
--- a/client/src/assets/TeamBuildApply.module.css
+++ b/client/src/assets/TeamBuildApply.module.css
@@ -196,6 +196,20 @@
   margin-top: 120px;
 }
 
+.completedActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.completedActions button {
+  flex: 1 1 160px;
+  min-height: 48px;
+  border-radius: 12px;
+  font-size: 14px;
+}
+
 .emptyApply {
   min-height: 240px;
   display: flex;

--- a/client/src/pages/TeamBuildApplyPage.js
+++ b/client/src/pages/TeamBuildApplyPage.js
@@ -450,6 +450,22 @@ function TeamBuildApplyPage({ round = 1 }) {
                 </div>
               ))}
             </div>
+            <div className={styles.completedActions}>
+              <button
+                type="button"
+                className={styles.keepApplicationButton}
+                onClick={() => navigate(-1)}
+              >
+                돌아가기
+              </button>
+              <button
+                type="button"
+                className={styles.primaryButton}
+                onClick={() => navigate("/team-build/result")}
+              >
+                팀 빌딩 결과 확인
+              </button>
+            </div>
           </section>
         </div>
       </div>


### PR DESCRIPTION
## 📌 관련 이슈

- 없음

## ✨ PR 세부 내용

지원 완료 화면에 이동 버튼이 없어 다음 화면으로 이동하기 어려웠습니다. 완료 화면에 ‘돌아가기’와 ‘팀 빌딩 결과 확인’ 버튼을 추가했습니다.

- ‘돌아가기’를 누르면 이전 화면으로 이동합니다.
- ‘팀 빌딩 결과 확인’을 누르면 `/team-build/result`로 이동합니다.
- 1·2차 지원 완료 직후와 이미 지원한 사용자의 재접속 시 표시합니다.
- 화면 너비에 따라 버튼이 줄바꿈되도록 스타일을 적용했습니다.

## 👀 확인해주세요!

- 지원 화면 및 인증 관련 기존 테스트 25개 통과 (2개 테스트 스위트)
- `git diff --check` 통과

## ⌛ 소요 시간

- 별도 측정하지 않음
