### PR TITLE
fix: 카카오 로그인 콜백 404 해결을 위한 Workers SPA 설정 추가

### DIFF
--- a/client/wrangler.jsonc
+++ b/client/wrangler.jsonc
@@ -1,0 +1,9 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "waps",
+  "compatibility_date": "2026-09-11",
+  "assets": {
+    "directory": "./build",
+    "not_found_handling": "single-page-application"
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈

- 별도 이슈 없음

## ✨ PR 세부 내용

카카오 인증 후 `/oauth/callback?token=...`으로 이동하면 Cloudflare Workers가 404를 반환해 React의 로그인 콜백 화면을 실행하지 못하는 문제를 수정합니다.

`client/wrangler.jsonc`에 빌드 산출물 경로(`./build`)와 `assets.not_found_handling: single-page-application`을 설정했습니다. 정적 파일이 없는 React 경로에는 `index.html`을 제공해 콜백 경로와 쿼리 문자열을 유지한 상태로 로그인 처리를 이어갑니다.

## 👀 확인해주세요!

- `npm run build` 성공 및 설정의 빌드 경로 확인을 완료했습니다.
- 운영 사이트에서 루트 경로는 200, 토큰 없는 `/oauth/callback`은 404인 것을 확인했습니다.
- Workers 배포 루트는 `client`, 빌드 명령은 `npm run build`, 배포 명령은 `npx wrangler deploy`입니다. 설정의 `name: waps`가 기존 Worker 이름과 일치하는지 확인해주세요.
- 운영 배포 후 카카오 로그인 완료와 React 경로 직접 접속을 확인해야 합니다.

## ⌛ 소요 시간

- 별도 기록 없음
