### PR TITLE
fix: 카카오 로그인 콜백 404 수정 운영 반영

### DIFF
--- a/client/wrangler.jsonc
+++ b/client/wrangler.jsonc
@@ -1,0 +1,9 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "waps",
+  "compatibility_date": "2026-09-11",
+  "assets": {
+    "directory": "./build",
+    "not_found_handling": "single-page-application"
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈

- 관련 PR: #671

## ✨ PR 세부 내용

카카오 인증 후 `/oauth/callback?token=...`에서 404가 발생하는 문제를 해결하기 위해 develop의 Cloudflare Workers SPA 설정을 main에 반영합니다.

`client/wrangler.jsonc`에 정적 파일 경로(`./build`)와 `assets.not_found_handling: single-page-application`을 추가했습니다. React 경로로 직접 접속하면 `index.html`을 제공해 콜백 주소와 쿼리 문자열을 유지한 채 로그인 처리를 진행합니다.

## 👀 확인해주세요!

- #671 작업에서 클라이언트 빌드와 설정의 빌드 경로 검증을 완료했습니다.
- 배포 시 설정의 `name: waps`가 기존 Worker 이름과 일치해야 합니다.
- Workers 배포 루트는 `client`, 빌드 명령은 `npm run build`, 배포 명령은 `npx wrangler deploy`입니다.
- 운영 배포 후 카카오 로그인과 React 경로 직접 접속을 확인해야 합니다.

## ⌛ 소요 시간

- 별도 기록 없음
